### PR TITLE
fix: cast CustomLabel to CustomLabels

### DIFF
--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -12,6 +12,7 @@ import { DeployResult } from '@salesforce/source-deploy-retrieve';
 import { Duration } from '@salesforce/kit';
 import { asString, asArray } from '@salesforce/ts-types';
 import * as chalk from 'chalk';
+import { ComponentLike } from '@salesforce/source-deploy-retrieve/lib/src/common';
 import { SourceCommand } from '../../../sourceCommand';
 
 Messages.importMessagesDirectory(__dirname);
@@ -114,6 +115,11 @@ export class Deploy extends SourceCommand {
     }
 
     return results;
+  }
+
+  protected makeComponentLike(metadata: string): ComponentLike {
+    const [type, fullName] = metadata.split(':');
+    return type === 'CustomLabel' ? { type: 'CustomLabels', fullName: '*' } : { type, fullName: fullName || '*' };
   }
 
   private printComponentFailures(result: DeployResult): void {

--- a/src/sourceCommand.ts
+++ b/src/sourceCommand.ts
@@ -71,8 +71,8 @@ export abstract class SourceCommand extends SfdxCommand {
     return new ComponentSet(setAggregator);
   }
 
-  private makeComponentLike(metadata: string): ComponentLike {
+  protected makeComponentLike(metadata: string): ComponentLike {
     const [type, fullName] = metadata.split(':');
-    return type === 'CustomLabel' ? { type: 'CustomLabels', fullName: '*' } : { type, fullName: fullName || '*' };
+    return { type, fullName: fullName || '*' };
   }
 }


### PR DESCRIPTION
### What does this PR do?
Casts `CustomLabel:foo_bar` to `CustomLabels:*` during source deploy

### What issues does this PR fix or reference?
[skip-validate-pr]