### PR TITLE
fix: deploy output fixes

### DIFF
--- a/messages/deploy.json
+++ b/messages/deploy.json
@@ -28,5 +28,7 @@
     "soapDeploy": "deploy metadata with SOAP API instead of REST API"
   },
   "checkOnlySuccess": "Successfully validated the deployment. %s components deployed and %s tests run.\nUse the --verbose parameter to see detailed output.",
-  "MissingDeployId": "No deploy ID was provided or found in deploy history"
+  "MissingDeployId": "No deploy ID was provided or found in deploy history",
+  "deployCanceled": "The deployment has been canceled by %s",
+  "deployFailed": "Deploy failed."
 }


### PR DESCRIPTION
### What does this PR do?
Fixes some deploy output bugs.

1. When an error happens during the deploy request (like a gack) the command was handling it properly when `--json` was specified but incorrectly when the progress bar was in use.  This was due to ignoring the event handling errors from SDR, so we now throw the error from the event.
2. Whenever the command was unsuccessful we need to throw from the output formatter so that the framework indicates an error.
3. The component failures were not being filtered and displayed properly.

@W-8903671@