### PR TITLE
fix: postretrieve hook payload is now the file responses

### DIFF
--- a/src/commands/force/source/retrieve.ts
+++ b/src/commands/force/source/retrieve.ts
@@ -116,8 +116,7 @@ export class Retrieve extends SourceCommand {
         complete = true;
       }
     }
-
-    await this.lifecycle.emit('postretrieve', this.retrieveResult.response);
+    await this.lifecycle.emit('postretrieve', this.retrieveResult.getFileResponses());
   }
 
   protected resolveSuccess(): void {

--- a/test/commands/source/retrieve.test.ts
+++ b/test/commands/source/retrieve.test.ts
@@ -139,7 +139,7 @@ describe('force:source:retrieve', () => {
     expect(lifecycleEmitStub.firstCall.args[0]).to.equal('preretrieve');
     expect(lifecycleEmitStub.firstCall.args[1]).to.deep.equal([exampleSourceComponent]);
     expect(lifecycleEmitStub.secondCall.args[0]).to.equal('postretrieve');
-    expect(lifecycleEmitStub.secondCall.args[1]).to.deep.equal(expectedResults.response);
+    expect(lifecycleEmitStub.secondCall.args[1]).to.deep.equal(expectedResults.inboundFiles);
   };
 
   it('should pass along sourcepath', async () => {


### PR DESCRIPTION
### What does this PR do?
The postretrieve hook payload is now the file responses, which more closely matches the old
postsourceupdate hook, rather than the raw server response.

### What issues does this PR fix or reference?
@W-9514884@