### PR TITLE
fix: display retrieve warnings

### DIFF
--- a/messages/retrieve.json
+++ b/messages/retrieve.json
@@ -23,6 +23,7 @@
   "SourceRetrieveError": "Could not retrieve files in the sourcepath%s",
   "retrieveTimeout": "Your retrieve request did not complete within the specified wait time [%s minutes]. Try again with a longer wait time.",
   "retrievedSourceHeader": "Retrieved Source",
+  "retrievedSourceWarningsHeader": "Retrieved Source Warnings",
   "fullNameTableColumn": "FULL NAME",
   "typeTableColumn": "TYPE",
   "workspacePathTableColumn": "PROJECT PATH",


### PR DESCRIPTION
### What does this PR do?
Changes the retrieveResultFormatter to display warnings properly.  Slight restructuring for easier readability.   Adds a few unit tests.  Without these changes warnings were not being displayed and the output was confusing.

### What issues does this PR fix or reference?
@W-9517801@