### PR TITLE
fix: set sourceApiVersion on the ComponentSet

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@oclif/config": "^1",
     "@salesforce/command": "^3.1.3",
     "@salesforce/core": "^2.23.4",
-    "@salesforce/source-deploy-retrieve": "^3.1.1",
+    "@salesforce/source-deploy-retrieve": "^3.1.2",
     "chalk": "^4.1.0",
     "cli-ux": "^5.5.1",
     "tslib": "^2"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@oclif/config": "^1",
     "@salesforce/command": "^3.1.3",
     "@salesforce/core": "^2.23.4",
-    "@salesforce/source-deploy-retrieve": "^3.1.2",
+    "@salesforce/source-deploy-retrieve": "^4.0.0",
     "chalk": "^4.1.0",
     "cli-ux": "^5.5.1",
     "tslib": "^2"

--- a/src/commands/force/source/convert.ts
+++ b/src/commands/force/source/convert.ts
@@ -81,6 +81,7 @@ export class Convert extends SourceCommand {
     }
 
     this.componentSet = await ComponentSetBuilder.build({
+      sourceapiversion: await this.getSourceApiVersion(),
       sourcepath: paths,
       manifest: manifest && {
         manifestPath: this.getFlag<string>('manifest'),
@@ -93,7 +94,7 @@ export class Convert extends SourceCommand {
     });
 
     const converter = new MetadataConverter();
-    this.convertResult = await converter.convert(this.componentSet.getSourceComponents().toArray(), 'metadata', {
+    this.convertResult = await converter.convert(this.componentSet, 'metadata', {
       type: 'directory',
       outputDirectory: this.getFlag<string>('outputdir'),
       packageName: this.getFlag<string>('packagename'),

--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -127,6 +127,7 @@ export class Deploy extends DeployCommand {
     } else {
       this.componentSet = await ComponentSetBuilder.build({
         apiversion: this.getFlag<string>('apiversion'),
+        sourceapiversion: await this.getSourceApiVersion(),
         sourcepath: this.getFlag<string[]>('sourcepath'),
         manifest: this.flags.manifest && {
           manifestPath: this.getFlag<string>('manifest'),

--- a/src/commands/force/source/retrieve.ts
+++ b/src/commands/force/source/retrieve.ts
@@ -71,6 +71,7 @@ export class Retrieve extends SourceCommand {
   protected async retrieve(): Promise<void> {
     this.componentSet = await ComponentSetBuilder.build({
       apiversion: this.getFlag<string>('apiversion'),
+      sourceapiversion: await this.getSourceApiVersion(),
       packagenames: this.getFlag<string[]>('packagenames'),
       sourcepath: this.getFlag<string[]>('sourcepath'),
       manifest: this.flags.manifest && {
@@ -89,7 +90,7 @@ export class Retrieve extends SourceCommand {
       usernameOrConnection: this.org.getUsername(),
       merge: true,
       output: this.project.getDefaultPackage().fullPath,
-      packageNames: this.getFlag<string[]>('packagenames'),
+      packageOptions: this.getFlag<string[]>('packagenames'),
     });
 
     this.retrieveResult = await mdapiRetrieve.pollStatus(1000, this.getFlag<Duration>('wait').seconds);

--- a/src/componentSetBuilder.ts
+++ b/src/componentSetBuilder.ts
@@ -24,6 +24,7 @@ export type ComponentSetOptions = {
   manifest?: ManifestOption;
   metadata?: MetadataOption;
   apiversion?: string;
+  sourceapiversion?: string;
 };
 
 export class ComponentSetBuilder {
@@ -39,7 +40,7 @@ export class ComponentSetBuilder {
     const logger = Logger.childFromRoot('createComponentSet');
     const csAggregator: ComponentLike[] = [];
 
-    const { sourcepath, manifest, metadata, packagenames, apiversion } = options;
+    const { sourcepath, manifest, metadata, packagenames, apiversion, sourceapiversion } = options;
 
     if (sourcepath) {
       logger.debug(`Building ComponentSet from sourcepath: ${sourcepath.toString()}`);
@@ -120,6 +121,10 @@ export class ComponentSetBuilder {
 
     if (apiversion) {
       componentSet.apiVersion = apiversion;
+    }
+
+    if (sourceapiversion) {
+      componentSet.sourceApiVersion = sourceapiversion;
     }
 
     return componentSet;

--- a/src/sourceCommand.ts
+++ b/src/sourceCommand.ts
@@ -8,7 +8,7 @@
 import { SfdxCommand } from '@salesforce/command';
 import { Lifecycle } from '@salesforce/core';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
-import { get, getBoolean } from '@salesforce/ts-types';
+import { get, getBoolean, getString, Optional } from '@salesforce/ts-types';
 import cli from 'cli-ux';
 
 export type ProgressBar = {
@@ -56,6 +56,11 @@ export abstract class SourceCommand extends SfdxCommand {
 
   protected getPackageDirs(): string[] {
     return this.project.getUniquePackageDirectories().map((pDir) => pDir.fullPath);
+  }
+
+  protected async getSourceApiVersion(): Promise<Optional<string>> {
+    const projectConfig = await this.project.resolveProjectConfig();
+    return getString(projectConfig, 'sourceApiVersion');
   }
 
   /**

--- a/test/commands/source/componentSetBuilder.test.ts
+++ b/test/commands/source/componentSetBuilder.test.ts
@@ -104,6 +104,24 @@ describe('ComponentSetBuilder', () => {
       expect(compSet.apiVersion).to.equal(options.apiversion);
     });
 
+    it('should create ComponentSet with sourceApiVersion', async () => {
+      fileExistsSyncStub.returns(true);
+      fromSourceStub.returns(componentSet);
+      const sourcepath = ['force-app'];
+      const options = {
+        sourcepath,
+        manifest: undefined,
+        metadata: undefined,
+        sourceapiversion: '50.0',
+      };
+
+      const compSet = await ComponentSetBuilder.build(options);
+      const expectedPath = path.resolve(sourcepath[0]);
+      expect(fromSourceStub.calledOnceWith(expectedPath)).to.equal(true);
+      expect(compSet.size).to.equal(0);
+      expect(compSet.sourceApiVersion).to.equal(options.sourceapiversion);
+    });
+
     it('should throw with an invalid sourcepath', async () => {
       fileExistsSyncStub.returns(false);
       const sourcepath = ['nonexistent'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,10 +823,10 @@
     unzipper "0.10.11"
     xmldom-sfdx-encoding "^0.1.29"
 
-"@salesforce/source-deploy-retrieve@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-3.1.1.tgz#47471b4841859876adda8471fad87971e9781e41"
-  integrity sha512-9KTLp/tJDThkwXvPGq4/MY/Y+28ykaPgX/xKMtvrZQEP20dJPv/tcTf7HtFQszO4LnX4C90g13XHrtQRodzkYw==
+"@salesforce/source-deploy-retrieve@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-4.0.0.tgz#a42d45afff683d00f449f09533e208438dc239b1"
+  integrity sha512-1ROnnCdY/q3C9xi0mPchoH+U5+00Df8pf6Nmf4ERcL3lpDnbjFbyZjQA+jkx2KmJKAf/AMjgXa/W6RAxV6CZSw==
   dependencies:
     "@salesforce/core" "2.25.1"
     "@salesforce/kit" "^1.5.0"


### PR DESCRIPTION
### What does this PR do?
Sets a sourceApiVersion on the ComponentSet when deploying and retrieving, based on a sourceApiVersion set in sfdx-project.json.

### What issues does this PR fix or reference?
@W-9604682@
