### PR TITLE
fix: deploy:report now respects the wait flag

### DIFF
--- a/messages/report.json
+++ b/messages/report.json
@@ -15,5 +15,6 @@
     "jobid": "job ID of the deployment you want to check; defaults to your most recent CLI deployment if not specified",
     "wait": "wait time for command to finish in minutes",
     "verbose": "verbose output of deploy result"
-  }
+  },
+  "mdapiDeployFailed": "The metadata deploy operation failed."
 }

--- a/src/commands/force/source/deploy/report.ts
+++ b/src/commands/force/source/deploy/report.ts
@@ -42,7 +42,6 @@ export class Report extends DeployCommand {
       description: messages.getMessage('flags.verbose'),
     }),
   };
-
   public async run(): Promise<DeployReportCommandResult> {
     await this.doReport();
     this.resolveSuccess();
@@ -54,7 +53,7 @@ export class Report extends DeployCommand {
    *
    * @param id
    */
-  public createDeploy(id: string): MetadataApiDeploy {
+  public createDeploy(id?: string): MetadataApiDeploy {
     return new MetadataApiDeploy({ usernameOrConnection: this.org.getUsername(), id });
   }
 

--- a/src/commands/force/source/deploy/report.ts
+++ b/src/commands/force/source/deploy/report.ts
@@ -8,13 +8,17 @@
 import * as os from 'os';
 import { Messages, SfdxProject } from '@salesforce/core';
 import { flags, FlagsConfig } from '@salesforce/command';
-import { Duration } from '@salesforce/kit';
+import { Duration, env } from '@salesforce/kit';
+import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
 import { DeployCommand } from '../../../../deployCommand';
 import {
   DeployReportCommandResult,
   DeployReportResultFormatter,
 } from '../../../../formatters/deployReportResultFormatter';
 import { ComponentSetBuilder } from '../../../../componentSetBuilder';
+import { ProgressFormatter } from '../../../../formatters/progressFormatter';
+import { DeployProgressBarFormatter } from '../../../../formatters/deployProgressBarFormatter';
+import { DeployProgressStatusFormatter } from '../../../../formatters/deployProgressStatusFormatter';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-source', 'report');
@@ -45,6 +49,15 @@ export class Report extends DeployCommand {
     return this.formatResult();
   }
 
+  /**
+   * This method is here to provide a workaround to stubbing a constructor in the tests.
+   *
+   * @param id
+   */
+  public createDeploy(id: string): MetadataApiDeploy {
+    return new MetadataApiDeploy({ usernameOrConnection: this.org.getUsername(), id });
+  }
+
   protected async doReport(): Promise<void> {
     const deployId = this.resolveDeployId(this.getFlag<string>('jobid'));
 
@@ -61,6 +74,16 @@ export class Report extends DeployCommand {
       }
       this.componentSet = await ComponentSetBuilder.build({ sourcepath });
     }
+
+    const waitDuration = this.getFlag<Duration>('wait');
+    const deploy = this.createDeploy(deployId);
+    if (!this.isJsonOutput()) {
+      const progressFormatter: ProgressFormatter = env.getBoolean('SFDX_USE_PROGRESS_BAR', true)
+        ? new DeployProgressBarFormatter(this.logger, this.ux)
+        : new DeployProgressStatusFormatter(this.logger, this.ux);
+      progressFormatter.progress(deploy);
+    }
+    await deploy.pollStatus(500, waitDuration.seconds);
     this.deployResult = await this.report(deployId);
   }
 

--- a/src/formatters/deployReportResultFormatter.ts
+++ b/src/formatters/deployReportResultFormatter.ts
@@ -5,8 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { MetadataApiDeployStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { MetadataApiDeployStatus, RequestStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
 import { getString } from '@salesforce/ts-types';
+import { SfdxError } from '@salesforce/core';
 import { DeployResultFormatter } from './deployResultFormatter';
 
 export type DeployReportCommandResult = MetadataApiDeployStatus;
@@ -35,10 +36,16 @@ export class DeployReportResultFormatter extends DeployResultFormatter {
       } else {
         this.ux.log('No components deployed');
       }
-      return;
+    } else {
+      this.displaySuccesses();
+      this.displayFailures();
+      this.displayTestResults();
     }
-    this.displaySuccesses();
-    this.displayFailures();
-    this.displayTestResults();
+
+    if (status === RequestStatus.Failed) {
+      throw SfdxError.create('@salesforce/plugin-source', 'report', 'mdapiDeployFailed');
+    }
+
+    return;
   }
 }

--- a/test/commands/source/report.test.ts
+++ b/test/commands/source/report.test.ts
@@ -12,10 +12,10 @@ import { fromStub, spyMethod, stubInterface, stubMethod } from '@salesforce/ts-s
 import { ConfigFile, Org, SfdxProject } from '@salesforce/core';
 import { IConfig } from '@oclif/config';
 import { UX } from '@salesforce/command';
+import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
 import { Report } from '../../../src/commands/force/source/deploy/report';
 import { DeployReportResultFormatter } from '../../../src/formatters/deployReportResultFormatter';
 import { DeployCommandResult } from '../../../src/formatters/deployResultFormatter';
-import { MetadataApiDeploy } from '../../../../source-deploy-retrieve';
 import { DeployProgressBarFormatter } from '../../../src/formatters/deployProgressBarFormatter';
 import { DeployProgressStatusFormatter } from '../../../src/formatters/deployProgressStatusFormatter';
 import { getDeployResult } from './deployResponses';


### PR DESCRIPTION
### What does this PR do?
the `deploy:report` command now uses the `--wait` flag
### What issues does this PR fix or reference?
@W-9642428@