### PR TITLE
fix: missing metadata type error matches toolbelt

### DIFF
--- a/test/commands/source/componentSetBuilder.test.ts
+++ b/test/commands/source/componentSetBuilder.test.ts
@@ -191,8 +191,7 @@ describe('ComponentSetBuilder', () => {
         assert.fail('the above should throw an error');
       } catch (e) {
         expect(e).to.not.be.null;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        expect(e.message).to.include("Missing metadata type definition in registry for id 'notatype'");
+        expect((e as Error).message).to.include('The specified metadata type is unsupported: [notatype]');
       }
     });
 

--- a/test/nuts/seeds/convert.seed.ts
+++ b/test/nuts/seeds/convert.seed.ts
@@ -87,7 +87,7 @@ context('Convert NUTs [name: %REPO_NAME%] [exec: %EXECUTABLE%]', () => {
 
     it('should throw an error if the metadata is not valid', async () => {
       const convert = await testkit.convert({ args: '--metadata DOES_NOT_EXIST', exitCode: 1 });
-      const expectedError = testkit.isLocalExecutable() ? 'RegistryError' : 'UnsupportedType';
+      const expectedError = testkit.isLocalExecutable() ? 'SfdxError' : 'UnsupportedType';
       testkit.expect.errorToHaveName(convert, expectedError);
     });
   });

--- a/test/nuts/seeds/deploy.metadata.seed.ts
+++ b/test/nuts/seeds/deploy.metadata.seed.ts
@@ -46,7 +46,7 @@ context('Deploy metadata NUTs [name: %REPO_NAME%] [exec: %EXECUTABLE%]', () => {
 
     it('should throw an error if the metadata is not valid', async () => {
       const deploy = await testkit.deploy({ args: '--metadata DOES_NOT_EXIST', exitCode: 1 });
-      const expectedError = testkit.isLocalExecutable() ? 'RegistryError' : 'UnsupportedType';
+      const expectedError = testkit.isLocalExecutable() ? 'SfdxError' : 'UnsupportedType';
       testkit.expect.errorToHaveName(deploy, expectedError);
     });
 

--- a/test/nuts/seeds/retrieve.metadata.seed.ts
+++ b/test/nuts/seeds/retrieve.metadata.seed.ts
@@ -71,7 +71,7 @@ context('Retrieve metadata NUTs [name: %REPO_NAME%] [exec: %EXECUTABLE%]', () =>
 
     it('should throw an error if the metadata is not valid', async () => {
       const retrieve = await testkit.retrieve({ args: '--metadata DOES_NOT_EXIST', exitCode: 1 });
-      const expectedError = testkit.isLocalExecutable() ? 'RegistryError' : 'UnsupportedType';
+      const expectedError = testkit.isLocalExecutable() ? 'SfdxError' : 'UnsupportedType';
       testkit.expect.errorToHaveName(retrieve, expectedError);
     });
   });


### PR DESCRIPTION
### What does this PR do?
catches and transforms the SDR error for a missing metadata type to match the toolbelt's

should hopefully defer blame to the user rather than us
### What issues does this PR fix or reference?
@W-9657211@