### PR TITLE
fix: alias SDR for path lengths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@oclif/config": "^1",
     "@salesforce/command": "^4.0.4",
     "@salesforce/core": "^2.26.1",
-    "@salesforce/source-deploy-retrieve": "^4.0.2",
+    "SDR": "npm:@salesforce/source-deploy-retrieve@^4.0.2",
     "chalk": "^4.1.1",
     "cli-ux": "^5.6.3",
     "open": "^8.2.1",

--- a/src/commands/force/source/convert.ts
+++ b/src/commands/force/source/convert.ts
@@ -8,7 +8,7 @@
 import * as os from 'os';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
-import { MetadataConverter, ConvertResult } from '@salesforce/source-deploy-retrieve';
+import { MetadataConverter, ConvertResult } from 'SDR';
 import { getString } from '@salesforce/ts-types';
 import { SourceCommand } from '../../../sourceCommand';
 import { ConvertResultFormatter, ConvertCommandResult } from '../../../formatters/convertResultFormatter';

--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -7,11 +7,11 @@
 import * as os from 'os';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Messages, SfdxError } from '@salesforce/core';
-import { AsyncResult, DeployResult } from '@salesforce/source-deploy-retrieve';
+import { AsyncResult, DeployResult } from 'SDR';
 import { Duration } from '@salesforce/kit';
 import { getString, isString } from '@salesforce/ts-types';
 import { env, once } from '@salesforce/kit';
-import { RequestStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { RequestStatus } from 'SDR/lib/src/client/types';
 import { DeployCommand } from '../../../deployCommand';
 import { ComponentSetBuilder } from '../../../componentSetBuilder';
 import { DeployResultFormatter, DeployCommandResult } from '../../../formatters/deployResultFormatter';

--- a/src/commands/force/source/deploy/cancel.ts
+++ b/src/commands/force/source/deploy/cancel.ts
@@ -10,7 +10,7 @@ import { flags, FlagsConfig } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import { getString } from '@salesforce/ts-types';
-import { RequestStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { RequestStatus } from 'SDR/lib/src/client/types';
 import { DeployCommand } from '../../../../deployCommand';
 import {
   DeployCancelCommandResult,

--- a/src/commands/force/source/deploy/report.ts
+++ b/src/commands/force/source/deploy/report.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
 import { Messages, SfdxProject } from '@salesforce/core';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Duration, env } from '@salesforce/kit';
-import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
+import { MetadataApiDeploy } from 'SDR';
 import { DeployCommand } from '../../../../deployCommand';
 import {
   DeployReportCommandResult,

--- a/src/commands/force/source/open.ts
+++ b/src/commands/force/source/open.ts
@@ -13,7 +13,7 @@ import { fs, AuthInfo } from '@salesforce/core';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Messages, sfdc, SfdxError } from '@salesforce/core';
 import checkLightningDomain from '@salesforce/core/lib/util/checkLightningDomain';
-import { SourceComponent, MetadataResolver } from '@salesforce/source-deploy-retrieve';
+import { SourceComponent, MetadataResolver } from 'SDR';
 import { OpenResultFormatter, OpenCommandResult } from '../../../formatters/openResultFormatter';
 import { SourceCommand } from '../../../sourceCommand';
 

--- a/src/commands/force/source/retrieve.ts
+++ b/src/commands/force/source/retrieve.ts
@@ -11,8 +11,8 @@ import { flags, FlagsConfig } from '@salesforce/command';
 import { Messages, SfdxProject } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import { getString } from '@salesforce/ts-types';
-import { RetrieveResult } from '@salesforce/source-deploy-retrieve';
-import { RequestStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { RetrieveResult } from 'SDR';
+import { RequestStatus } from 'SDR/lib/src/client/types';
 import { SourceCommand } from '../../../sourceCommand';
 import {
   RetrieveResultFormatter,

--- a/src/componentSetBuilder.ts
+++ b/src/componentSetBuilder.ts
@@ -6,8 +6,8 @@
  */
 
 import * as path from 'path';
-import { ComponentSet, RegistryAccess } from '@salesforce/source-deploy-retrieve';
-import { ComponentLike } from '@salesforce/source-deploy-retrieve/lib/src/resolve/types';
+import { ComponentSet, RegistryAccess } from 'SDR';
+import { ComponentLike } from 'SDR/lib/src/resolve/types';
 import { fs, SfdxError, Logger } from '@salesforce/core';
 
 export type ManifestOption = {

--- a/src/deployCommand.ts
+++ b/src/deployCommand.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ComponentSet, DeployResult } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet, DeployResult } from 'SDR';
 import { SfdxError, ConfigFile, ConfigAggregator, PollingClient, StatusResult } from '@salesforce/core';
-import { MetadataApiDeployStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { MetadataApiDeployStatus } from 'SDR/lib/src/client/types';
 import { AnyJson, asString, getBoolean } from '@salesforce/ts-types';
 import { Duration, once } from '@salesforce/kit';
 import { SourceCommand } from './sourceCommand';

--- a/src/formatters/convertResultFormatter.ts
+++ b/src/formatters/convertResultFormatter.ts
@@ -8,7 +8,7 @@
 import { resolve } from 'path';
 import { UX } from '@salesforce/command';
 import { Logger, Messages, SfdxError } from '@salesforce/core';
-import { ConvertResult } from '@salesforce/source-deploy-retrieve';
+import { ConvertResult } from 'SDR';
 import { ResultFormatter } from './resultFormatter';
 
 Messages.importMessagesDirectory(__dirname);

--- a/src/formatters/deployAsyncResultFormatter.ts
+++ b/src/formatters/deployAsyncResultFormatter.ts
@@ -9,7 +9,7 @@ import { EOL } from 'os';
 import { UX } from '@salesforce/command';
 import { Logger, Messages } from '@salesforce/core';
 import { cloneJson } from '@salesforce/kit';
-import { AsyncResult } from '@salesforce/source-deploy-retrieve';
+import { AsyncResult } from 'SDR';
 import { ResultFormatter, ResultFormatterOptions } from './resultFormatter';
 
 Messages.importMessagesDirectory(__dirname);

--- a/src/formatters/deployCancelResultFormatter.ts
+++ b/src/formatters/deployCancelResultFormatter.ts
@@ -8,8 +8,8 @@
 import { UX } from '@salesforce/command';
 import { Logger } from '@salesforce/core';
 import { getString } from '@salesforce/ts-types';
-import { DeployResult } from '@salesforce/source-deploy-retrieve';
-import { MetadataApiDeployStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { DeployResult } from 'SDR';
+import { MetadataApiDeployStatus } from 'SDR/lib/src/client/types';
 import { ResultFormatter } from './resultFormatter';
 
 export type DeployCancelCommandResult = MetadataApiDeployStatus;

--- a/src/formatters/deployProgressBarFormatter.ts
+++ b/src/formatters/deployProgressBarFormatter.ts
@@ -6,7 +6,7 @@
  */
 import { UX } from '@salesforce/command';
 import { Logger } from '@salesforce/core';
-import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
+import { MetadataApiDeploy } from 'SDR';
 import { once } from '@salesforce/kit';
 import cli from 'cli-ux';
 import { ProgressBar } from '../sourceCommand';

--- a/src/formatters/deployProgressStatusFormatter.ts
+++ b/src/formatters/deployProgressStatusFormatter.ts
@@ -8,8 +8,8 @@ import * as chalk from 'chalk';
 import { UX } from '@salesforce/command';
 import { Logger } from '@salesforce/core';
 import { getNumber } from '@salesforce/ts-types';
-import { MetadataApiDeployStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
-import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
+import { MetadataApiDeployStatus } from 'SDR/lib/src/client/types';
+import { MetadataApiDeploy } from 'SDR';
 import { Duration } from '@salesforce/kit';
 import { ProgressFormatter } from './progressFormatter';
 export class DeployProgressStatusFormatter extends ProgressFormatter {

--- a/src/formatters/deployReportResultFormatter.ts
+++ b/src/formatters/deployReportResultFormatter.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { MetadataApiDeployStatus, RequestStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { MetadataApiDeployStatus, RequestStatus } from 'SDR/lib/src/client/types';
 import { getString } from '@salesforce/ts-types';
 import { SfdxError } from '@salesforce/core';
 import { DeployResultFormatter } from './deployResultFormatter';

--- a/src/formatters/deployResultFormatter.ts
+++ b/src/formatters/deployResultFormatter.ts
@@ -9,13 +9,8 @@ import * as chalk from 'chalk';
 import { UX } from '@salesforce/command';
 import { Logger, Messages, SfdxError } from '@salesforce/core';
 import { get, getBoolean, getString, getNumber, asString } from '@salesforce/ts-types';
-import { DeployResult } from '@salesforce/source-deploy-retrieve';
-import {
-  CodeCoverage,
-  FileResponse,
-  MetadataApiDeployStatus,
-  RequestStatus,
-} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { DeployResult } from 'SDR';
+import { CodeCoverage, FileResponse, MetadataApiDeployStatus, RequestStatus } from 'SDR/lib/src/client/types';
 import { ResultFormatter, ResultFormatterOptions, toArray } from './resultFormatter';
 
 Messages.importMessagesDirectory(__dirname);

--- a/src/formatters/progressFormatter.ts
+++ b/src/formatters/progressFormatter.ts
@@ -7,7 +7,7 @@
 
 import { UX } from '@salesforce/command';
 import { Logger } from '@salesforce/core';
-import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
+import { MetadataApiDeploy } from 'SDR';
 
 export abstract class ProgressFormatter {
   public logger: Logger;

--- a/src/formatters/resultFormatter.ts
+++ b/src/formatters/resultFormatter.ts
@@ -8,9 +8,9 @@
 import * as path from 'path';
 import { UX } from '@salesforce/command';
 import { Logger } from '@salesforce/core';
-import { FileResponse } from '@salesforce/source-deploy-retrieve';
+import { FileResponse } from 'SDR';
 import { getBoolean, getNumber } from '@salesforce/ts-types';
-import { Failures, Successes } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { Failures, Successes } from 'SDR/lib/src/client/types';
 
 export interface ResultFormatterOptions {
   verbose?: boolean;

--- a/src/formatters/retrieveResultFormatter.ts
+++ b/src/formatters/retrieveResultFormatter.ts
@@ -9,13 +9,8 @@ import { blue, yellow } from 'chalk';
 import { UX } from '@salesforce/command';
 import { Logger, Messages, SfdxError } from '@salesforce/core';
 import { get, getString, getNumber } from '@salesforce/ts-types';
-import { RetrieveResult, MetadataApiRetrieveStatus } from '@salesforce/source-deploy-retrieve';
-import {
-  ComponentStatus,
-  FileResponse,
-  RequestStatus,
-  RetrieveMessage,
-} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { RetrieveResult, MetadataApiRetrieveStatus } from 'SDR';
+import { ComponentStatus, FileResponse, RequestStatus, RetrieveMessage } from 'SDR/lib/src/client/types';
 import { ResultFormatter, ResultFormatterOptions, toArray } from './resultFormatter';
 
 Messages.importMessagesDirectory(__dirname);

--- a/src/sourceCommand.ts
+++ b/src/sourceCommand.ts
@@ -7,7 +7,7 @@
 
 import { SfdxCommand } from '@salesforce/command';
 import { Lifecycle } from '@salesforce/core';
-import { ComponentSet } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet } from 'SDR';
 import { get, getBoolean, getString, Optional } from '@salesforce/ts-types';
 import cli from 'cli-ux';
 

--- a/test/commands/source/componentSetBuilder.test.ts
+++ b/test/commands/source/componentSetBuilder.test.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { assert, expect } from 'chai';
-import { ComponentSet, FromSourceOptions } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet, FromSourceOptions } from 'SDR';
 import { stubMethod } from '@salesforce/ts-sinon';
 import { fs as fsCore, SfdxError } from '@salesforce/core';
 import { ComponentSetBuilder } from '../../../src/componentSetBuilder';

--- a/test/commands/source/convert.test.ts
+++ b/test/commands/source/convert.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { join, resolve } from 'path';
-import { MetadataConverter } from '@salesforce/source-deploy-retrieve';
+import { MetadataConverter } from 'SDR';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';

--- a/test/commands/source/deploy.test.ts
+++ b/test/commands/source/deploy.test.ts
@@ -8,7 +8,7 @@
 import { join } from 'path';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { MetadataApiDeployOptions } from '@salesforce/source-deploy-retrieve';
+import { MetadataApiDeployOptions } from 'SDR';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { ConfigAggregator, Lifecycle, Org, SfdxProject, Messages } from '@salesforce/core';
 import { UX } from '@salesforce/command';

--- a/test/commands/source/deployResponses.ts
+++ b/test/commands/source/deployResponses.ts
@@ -5,12 +5,8 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { DeployResult } from '@salesforce/source-deploy-retrieve';
-import {
-  DeployMessage,
-  MetadataApiDeployStatus,
-  RequestStatus,
-} from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { DeployResult } from 'SDR';
+import { DeployMessage, MetadataApiDeployStatus, RequestStatus } from 'SDR/lib/src/client/types';
 import { cloneJson } from '@salesforce/kit';
 import { toArray } from '../../../src/formatters/resultFormatter';
 

--- a/test/commands/source/open.test.ts
+++ b/test/commands/source/open.test.ts
@@ -8,7 +8,7 @@
 import { join } from 'path';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { SourceComponent, MetadataResolver } from '@salesforce/source-deploy-retrieve';
+import { SourceComponent, MetadataResolver } from 'SDR';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { IConfig } from '@oclif/config';
 import { AuthInfo, SfdxProject, Org, fs, MyDomainResolver } from '@salesforce/core';

--- a/test/commands/source/report.test.ts
+++ b/test/commands/source/report.test.ts
@@ -12,7 +12,7 @@ import { fromStub, spyMethod, stubInterface, stubMethod } from '@salesforce/ts-s
 import { ConfigFile, Org, SfdxProject } from '@salesforce/core';
 import { IConfig } from '@oclif/config';
 import { UX } from '@salesforce/command';
-import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
+import { MetadataApiDeploy } from 'SDR';
 import { Report } from '../../../src/commands/force/source/deploy/report';
 import { DeployReportResultFormatter } from '../../../src/formatters/deployReportResultFormatter';
 import { DeployCommandResult } from '../../../src/formatters/deployResultFormatter';

--- a/test/commands/source/retrieve.test.ts
+++ b/test/commands/source/retrieve.test.ts
@@ -8,7 +8,7 @@
 import { join } from 'path';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { RetrieveOptions } from '@salesforce/source-deploy-retrieve';
+import { RetrieveOptions } from 'SDR';
 import { Lifecycle, Org, SfdxProject } from '@salesforce/core';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { IConfig } from '@oclif/config';

--- a/test/commands/source/retrieveResponses.ts
+++ b/test/commands/source/retrieveResponses.ts
@@ -5,9 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { RetrieveResult } from '@salesforce/source-deploy-retrieve';
-import { RequestStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
-import { MetadataApiRetrieveStatus } from '@salesforce/source-deploy-retrieve/lib/src/client/types';
+import { RetrieveResult } from 'SDR';
+import { RequestStatus } from 'SDR/lib/src/client/types';
+import { MetadataApiRetrieveStatus } from 'SDR/lib/src/client/types';
 import { toArray } from '../../../src/formatters/resultFormatter';
 
 const packageFileProp = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -843,22 +843,6 @@
     unzipper "0.10.11"
     xmldom-sfdx-encoding "^0.1.29"
 
-"@salesforce/source-deploy-retrieve@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-4.0.2.tgz#2a272a1f6d8bb44513cfc296eab90d161357ed53"
-  integrity sha512-9qlSqrUCpMr7c9NoWAlFZRD7SEkrYCnoqT7A3T+CRvZeAaRB3cFRiveYRGNNnlAViqpYqgOI4lTNiBt3yTekQg==
-  dependencies:
-    "@salesforce/core" "2.25.1"
-    "@salesforce/kit" "^1.5.0"
-    "@salesforce/ts-types" "^1.4.2"
-    archiver "^5.3.0"
-    fast-xml-parser "^3.17.4"
-    gitignore-parser "0.0.2"
-    ignore "^5.1.8"
-    mime "2.4.6"
-    unzipper "0.10.11"
-    xmldom-sfdx-encoding "^0.1.29"
-
 "@salesforce/source-testkit@^0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@salesforce/source-testkit/-/source-testkit-0.0.5.tgz#9f9a83be85cbfbbf1fdf0bd3a5298d9391e2740f"
@@ -1174,6 +1158,22 @@ JSONStream@^1.0.4, JSONStream@^1.2.1, JSONStream@^1.3.5:
   dependencies:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
+
+"SDR@npm:@salesforce/source-deploy-retrieve@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-4.0.2.tgz#2a272a1f6d8bb44513cfc296eab90d161357ed53"
+  integrity sha512-9qlSqrUCpMr7c9NoWAlFZRD7SEkrYCnoqT7A3T+CRvZeAaRB3cFRiveYRGNNnlAViqpYqgOI4lTNiBt3yTekQg==
+  dependencies:
+    "@salesforce/core" "2.25.1"
+    "@salesforce/kit" "^1.5.0"
+    "@salesforce/ts-types" "^1.4.2"
+    archiver "^5.3.0"
+    fast-xml-parser "^3.17.4"
+    gitignore-parser "0.0.2"
+    ignore "^5.1.8"
+    mime "2.4.6"
+    unzipper "0.10.11"
+    xmldom-sfdx-encoding "^0.1.29"
 
 acorn-jsx@^5.3.1:
   version "5.3.2"


### PR DESCRIPTION
### What does this PR do?
shortens `@salesforce/source-deploy-retrieve` to `SDR` for path length issues while releasing `sfdx-cli`
### What issues does this PR fix or reference?
