### PR TITLE
Wr/convert package names

### DIFF
--- a/src/commands/force/source/convert.ts
+++ b/src/commands/force/source/convert.ts
@@ -95,7 +95,8 @@ export class Convert extends SourceCommand {
     });
 
     const packageName = this.getFlag<string>('packagename');
-    const outputDirectory = this.getFlag<string>('outputdir');
+    const outputDirectory =
+      this.getFlag<string>('outputdir') === './' ? `metadataPackage_${Date.now()}` : this.getFlag<string>('outputdir');
     const converter = new MetadataConverter();
     this.convertResult = await converter.convert(this.componentSet, 'metadata', {
       type: 'directory',
@@ -114,6 +115,7 @@ export class Convert extends SourceCommand {
       const tempDir = join(os.tmpdir(), `metadataPackage_${Date.now()}`);
       fs.renameSync(this.convertResult.packagePath, tempDir);
       fs.renameSync(tempDir, outputDirectory);
+      this.convertResult.packagePath = outputDirectory;
     }
   }
 

--- a/test/nuts/seeds/convert.seed.ts
+++ b/test/nuts/seeds/convert.seed.ts
@@ -59,6 +59,25 @@ context('Convert NUTs [name: %REPO_NAME%] [exec: %EXECUTABLE%]', () => {
       });
     }
 
+    for (const testCase of REPO.convert.manifest) {
+      it(`should convert ${testCase.toConvert} to default outputdir`, async () => {
+        // Generate a package.xml by converting via sourcepath
+        await testkit.convert({ args: `--sourcepath ${testCase.toConvert}` });
+        const packageXml = 'package.xml';
+
+        await testkit.convert({ args: `--manifest ${packageXml} --outputdir out2` });
+        await testkit.expect.directoryToHaveSomeFiles('out2');
+        await testkit.expect.fileToExist(path.join('out2', 'package.xml'));
+        await testkit.expect.filesToBeConverted('out2', testCase.toVerify);
+      });
+
+      afterEach(() => {
+        if (convertDir) {
+          shelljs.rm('-rf', convertDir);
+        }
+      });
+    }
+
     it('should throw an error if the package.xml is not valid', async () => {
       const convert = await testkit.convert({ args: '--manifest DOES_NOT_EXIST.xml', exitCode: 1 });
       testkit.expect.errorToHaveName(convert, 'Error');

--- a/test/nuts/seeds/convert.seed.ts
+++ b/test/nuts/seeds/convert.seed.ts
@@ -59,25 +59,6 @@ context('Convert NUTs [name: %REPO_NAME%] [exec: %EXECUTABLE%]', () => {
       });
     }
 
-    for (const testCase of REPO.convert.manifest) {
-      it(`should convert ${testCase.toConvert} to default outputdir`, async () => {
-        // Generate a package.xml by converting via sourcepath
-        await testkit.convert({ args: `--sourcepath ${testCase.toConvert}` });
-        const packageXml = 'package.xml';
-
-        await testkit.convert({ args: `--manifest ${packageXml} --outputdir out2` });
-        await testkit.expect.directoryToHaveSomeFiles('out2');
-        await testkit.expect.fileToExist(path.join('out2', 'package.xml'));
-        await testkit.expect.filesToBeConverted('out2', testCase.toVerify);
-      });
-
-      afterEach(() => {
-        if (convertDir) {
-          shelljs.rm('-rf', convertDir);
-        }
-      });
-    }
-
     it('should throw an error if the package.xml is not valid', async () => {
       const convert = await testkit.convert({ args: '--manifest DOES_NOT_EXIST.xml', exitCode: 1 });
       testkit.expect.errorToHaveName(convert, 'Error');


### PR DESCRIPTION
### What does this PR do?
`source:convert` now matches toolbelt's default behavior with default `--outputdir` and a specified `--outputdir`
### What issues does this PR fix or reference?
@W-9735120@