### PR TITLE
fix: trim metadata type, and name to prevent unnecessary errors

### DIFF
--- a/src/componentSetBuilder.ts
+++ b/src/componentSetBuilder.ts
@@ -82,10 +82,10 @@ export class ComponentSetBuilder {
         metadata.metadataEntries.forEach((rawEntry) => {
           const splitEntry = rawEntry.split(':');
           // The registry will throw if it doesn't know what this type is.
-          registry.getTypeByName(splitEntry[0]);
+          registry.getTypeByName(splitEntry[0].trim());
           const entry = {
             type: splitEntry[0],
-            fullName: splitEntry.length === 1 ? '*' : splitEntry[1],
+            fullName: splitEntry.length === 1 ? '*' : splitEntry[1].trim(),
           };
           // Add to the filtered ComponentSet for resolved source paths,
           // and the unfiltered ComponentSet to build the correct manifest.

--- a/test/commands/source/componentSetBuilder.test.ts
+++ b/test/commands/source/componentSetBuilder.test.ts
@@ -177,6 +177,31 @@ describe('ComponentSetBuilder', () => {
       expect(compSet.has({ type: 'ApexClass', fullName: '*' })).to.equal(true);
     });
 
+    it('should create ComponentSet from metadata with spaces between : (ApexClass: MyApexClass)', async () => {
+      componentSet.add(apexClassComponent);
+      fromSourceStub.returns(componentSet);
+      const packageDir1 = path.resolve('force-app');
+
+      const compSet = await ComponentSetBuilder.build({
+        sourcepath: undefined,
+        manifest: undefined,
+        metadata: {
+          metadataEntries: ['ApexClass: MyApexClass'],
+          directoryPaths: [packageDir1],
+        },
+      });
+      expect(fromSourceStub.calledOnce).to.equal(true);
+      const fromSourceArgs = fromSourceStub.firstCall.args[0] as FromSourceOptions;
+      expect(fromSourceArgs).to.have.deep.property('fsPaths', [packageDir1]);
+      const filter = new ComponentSet();
+      filter.add({ type: 'ApexClass', fullName: 'MyApexClass' });
+      expect(fromSourceArgs).to.have.property('include');
+      expect(fromSourceArgs.include.getSourceComponents()).to.deep.equal(filter.getSourceComponents());
+      expect(compSet.size).to.equal(2);
+      expect(compSet.has(apexClassComponent)).to.equal(true);
+      expect(compSet.has({ type: 'ApexClass', fullName: 'MyApexClass' })).to.equal(true);
+    });
+
     it('should throw an error when it cant resolve a metadata type (Metadata)', async () => {
       const packageDir1 = path.resolve('force-app');
 


### PR DESCRIPTION
### What does this PR do?
`deploy -m "ApexClass: GeocodingService" would cause a `no source backed components` Error, trim the metadata type and name to ensure we're parsing everything correctly

### What issues does this PR fix or reference?
@W-9803972@  https://github.com/forcedotcom/cli/issues/1151