### PR TITLE
help: put back the long param descriptions for force:source:deploy

### DIFF
--- a/messages/deploy.json
+++ b/messages/deploy.json
@@ -1,5 +1,5 @@
 {
-  "description": "deploy source to an org Use this command to deploy source (metadata that’s in source format) to an org.\nTo take advantage of change tracking with scratch orgs, use \"sfdx force:source:push\".\nTo deploy metadata that’s in metadata format, use \"sfdx force:mdapi:deploy\".\n\nThe source you deploy overwrites the corresponding metadata in your org. This command does not attempt to merge your source with the versions in your org.\n\nTo run the command asynchronously, set --wait to 0, which immediately returns the job ID. This way, you can continue to use the CLI.\nTo check the status of the job, use force:source:deploy:report.\n\nIf the comma-separated list you’re supplying contains spaces, enclose the entire comma-separated list in one set of double quotes. On Windows, if the list contains commas, also enclose the entire list in one set of double quotes.\n",
+  "description": "deploy source to an org\nUse this command to deploy source (metadata that’s in source format) to an org.\nTo take advantage of change tracking with scratch orgs, use \"sfdx force:source:push\".\nTo deploy metadata that’s in metadata format, use \"sfdx force:mdapi:deploy\".\n\nThe source you deploy overwrites the corresponding metadata in your org. This command does not attempt to merge your source with the versions in your org.\n\nTo run the command asynchronously, set --wait to 0, which immediately returns the job ID. This way, you can continue to use the CLI.\nTo check the status of the job, use force:source:deploy:report.\n\nIf the comma-separated list you’re supplying contains spaces, enclose the entire comma-separated list in one set of double quotes. On Windows, if the list contains commas, also enclose the entire list in one set of double quotes.\n",
   "examples": [
     "To deploy the source files in a directory:\n\t $ sfdx force:source:deploy -p path/to/source",
     "To deploy a specific Apex class and the objects whose source is in a directory: \n\t$ sfdx force:source:deploy -p \"path/to/apex/classes/MyClass.cls,path/to/source/objects\"",
@@ -27,46 +27,48 @@
     "validateDeployRequestId": "deploy request ID of the validated deployment to run a Quick Deploy",
     "soapDeploy": "deploy metadata with SOAP API instead of REST API"
   },
-    "longDescriptionMetadata": [
-    "A comma-separated list of names of metadata components to deploy to the org.",
-    "If you specify this parameter, don’t specify --manifest or --sourcepath."
-  ],
-  "longDescriptionManifest": [
-    "The complete path for the manifest (package.xml) file that specifies the components to deploy. All child components are included.",
-    "If you specify this parameter, don’t specify --metadata or --sourcepath."
-  ],
-  "longDescriptionSourcePath": [
-    "A comma-separated list of paths to the local source files to deploy. The supplied paths can be to a single file (in which case the operation is applied to only one file) or to a folder (in which case the operation is applied to all metadata types in the directory and its sub-directories).",
-    "If you specify this parameter, don’t specify --manifest or --metadata."
-  ],
-  "longDescriptionValidateDeploy": [
-    "Specifies the ID of a package with recently validated components to run a Quick Deploy. Deploying a validation helps you shorten your deployment time because tests aren’t rerun. If you have a recent successful validation, you can deploy the validated components without running tests. A validation doesn’t save any components in the org. You use a validation only to check the success or failure messages that you would receive with an actual deployment. To validate your components, add the -c | --checkonly flag when you run \"sfdx force:mdapi:deploy\". This flag sets the checkOnly=\"true\" parameter for your deployment. Before deploying a recent validation, ensure that the following requirements are met:",
-    "  1. The components have been validated successfully for the target environment within the last 10 days.",
-    "  2. As part of the validation, Apex tests in the target org have passed.",
-    "  3. Code coverage requirements are met.",
-    "    - If all tests in the org or all local tests are run, overall code coverage is at least 75%, and Apex triggers have some coverage.",
-    "    - If specific tests are run with the RunSpecifiedTests test level, each class and trigger that was deployed is covered by at least 75% individually."
-  ],
-  "longDescriptionIgnoreWarnings": "If a warning occurs and ignoreWarnings is set to true, the success field in DeployMessage is true. When ignoreWarnings is set to false, success is set to false, and the warning is treated like an error.",
-  "longDescriptionIgnoreErrors": "Ignores the deploy errors, and continues with the deploy operation. The default is false. Keep this parameter set to false when deploying to a production org. If set to true, components without errors are deployed, and components with errors are skipped.",
-  "longDescriptionRunTests": "Lists the Apex classes containing the deployment tests to run. Use this parameter when you set --testlevel to RunSpecifiedTests.",
-  "longDescriptionWait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you. ",
-  "longDescriptionTestLevel": [
-    "Specifies which level of deployment tests to run. Valid values are:",
-    "  NoTestRun—No tests are run. This test level applies only to deployments to development environments, such as sandbox, Developer Edition, or trial orgs. This test level is the default for development environments.",
-    "  RunSpecifiedTests—Runs only the tests that you specify in the --runtests option. Code coverage requirements differ from the default coverage requirements when using this test level. Executed tests must comprise a minimum of 75% code coverage for each class and trigger in the deployment package. This coverage is computed for each class and trigger individually and is different than the overall coverage percentage.",
-    "  RunLocalTests—All tests in your org are run, except the ones that originate from installed managed packages. This test level is the default for production deployments that include Apex classes or triggers.",
-    "  RunAllTestsInOrg—All tests in your org are run, including tests of managed packages.",
-    "If you don’t specify a test level, the default behavior depends on the contents of your deployment package. For more information, see “Running Tests in a Deployment” in the Metadata API Developer Guide."
-  ],
-    "longDescriptionCheckOnly": [
-    "Validates the deployed metadata and runs all Apex tests, but prevents the deployment from being saved to the org.",
-    "If you change a field type from Master-Detail to Lookup or vice versa, that change isn’t supported when using the --checkonly parameter to test a deployment (validation). This kind of change isn’t supported for test deployments to avoid the risk of data loss or corruption. If a change that isn’t supported for test deployments is included in a deployment package, the test deployment fails and issues an error.",
-    "If your deployment package changes a field type from Master-Detail to Lookup or vice versa, you can still validate the changes prior to deploying to Production by performing a full deployment to another test Sandbox. A full deployment includes a validation of the changes as part of the deployment process.",
-    "Note: A Metadata API deployment that includes Master-Detail relationships deletes all detail records in the Recycle Bin in the following cases.",
-    "1. For a deployment with a new Master-Detail field, soft delete (send to the Recycle Bin) all detail records before proceeding to deploy the Master-Detail field, or the deployment fails. During the deployment, detail records are permanently deleted from the Recycle Bin and cannot be recovered.",
-    "2. For a deployment that converts a Lookup field relationship to a Master-Detail relationship, detail records must reference a master record or be soft-deleted (sent to the Recycle Bin) for the deployment to succeed. However, a successful deployment permanently deletes any detail records in the Recycle Bin."
-  ],
+  "flagsLong": {
+    "sourcePath": [
+      "A comma-separated list of paths to the local source files to deploy. The supplied paths can be to a single file (in which case the operation is applied to only one file) or to a folder (in which case the operation is applied to all metadata types in the directory and its sub-directories).",
+      "If you specify this parameter, don’t specify --manifest or --metadata."
+    ],
+    "manifest": [
+      "The complete path for the manifest (package.xml) file that specifies the components to deploy. All child components are included.",
+      "If you specify this parameter, don’t specify --metadata or --sourcepath."
+    ],
+    "metadata": [
+      "A comma-separated list of names of metadata components to deploy to the org.",
+      "If you specify this parameter, don’t specify --manifest or --sourcepath."
+    ],
+    "wait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you. ",
+    "checkonly": [
+      "Validates the deployed metadata and runs all Apex tests, but prevents the deployment from being saved to the org.",
+      "If you change a field type from Master-Detail to Lookup or vice versa, that change isn’t supported when using the --checkonly parameter to test a deployment (validation). This kind of change isn’t supported for test deployments to avoid the risk of data loss or corruption. If a change that isn’t supported for test deployments is included in a deployment package, the test deployment fails and issues an error.",
+      "If your deployment package changes a field type from Master-Detail to Lookup or vice versa, you can still validate the changes prior to deploying to Production by performing a full deployment to another test Sandbox. A full deployment includes a validation of the changes as part of the deployment process.",
+      "Note: A Metadata API deployment that includes Master-Detail relationships deletes all detail records in the Recycle Bin in the following cases.",
+      "1. For a deployment with a new Master-Detail field, soft delete (send to the Recycle Bin) all detail records before proceeding to deploy the Master-Detail field, or the deployment fails. During the deployment, detail records are permanently deleted from the Recycle Bin and cannot be recovered.",
+      "2. For a deployment that converts a Lookup field relationship to a Master-Detail relationship, detail records must reference a master record or be soft-deleted (sent to the Recycle Bin) for the deployment to succeed. However, a successful deployment permanently deletes any detail records in the Recycle Bin."
+    ],
+    "testLevel": [
+      "Specifies which level of deployment tests to run. Valid values are:",
+      "  NoTestRun—No tests are run. This test level applies only to deployments to development environments, such as sandbox, Developer Edition, or trial orgs. This test level is the default for development environments.",
+      "  RunSpecifiedTests—Runs only the tests that you specify in the --runtests option. Code coverage requirements differ from the default coverage requirements when using this test level. Executed tests must comprise a minimum of 75% code coverage for each class and trigger in the deployment package. This coverage is computed for each class and trigger individually and is different than the overall coverage percentage.",
+      "  RunLocalTests—All tests in your org are run, except the ones that originate from installed managed packages. This test level is the default for production deployments that include Apex classes or triggers.",
+      "  RunAllTestsInOrg—All tests in your org are run, including tests of managed packages.",
+      "If you don’t specify a test level, the default behavior depends on the contents of your deployment package. For more information, see “Running Tests in a Deployment” in the Metadata API Developer Guide."
+    ],
+    "runTests": "Lists the Apex classes containing the deployment tests to run. Use this parameter when you set --testlevel to RunSpecifiedTests.",
+    "ignoreErrors": "Ignores the deploy errors, and continues with the deploy operation. The default is false. Keep this parameter set to false when deploying to a production org. If set to true, components without errors are deployed, and components with errors are skipped.",
+    "ignoreWarnings": "If a warning occurs and ignoreWarnings is set to true, the success field in DeployMessage is true. When ignoreWarnings is set to false, success is set to false, and the warning is treated like an error.",
+    "validateDeployRequestId": [
+      "Specifies the ID of a package with recently validated components to run a Quick Deploy. Deploying a validation helps you shorten your deployment time because tests aren’t rerun. If you have a recent successful validation, you can deploy the validated components without running tests. A validation doesn’t save any components in the org. You use a validation only to check the success or failure messages that you would receive with an actual deployment. To validate your components, add the -c | --checkonly flag when you run \"sfdx force:mdapi:deploy\". This flag sets the checkOnly=\"true\" parameter for your deployment. Before deploying a recent validation, ensure that the following requirements are met:",
+      "  1. The components have been validated successfully for the target environment within the last 10 days.",
+      "  2. As part of the validation, Apex tests in the target org have passed.",
+      "  3. Code coverage requirements are met.",
+      "    - If all tests in the org or all local tests are run, overall code coverage is at least 75%, and Apex triggers have some coverage.",
+      "    - If specific tests are run with the RunSpecifiedTests test level, each class and trigger that was deployed is covered by at least 75% individually."
+    ]
+  },
   "MissingRequiredParam": "Missing one of the following parameters: %s",
   "checkOnlySuccess": "Successfully validated the deployment. %s components deployed and %s tests run.\nUse the --verbose parameter to see detailed output.",
   "MissingDeployId": "No deploy ID was provided or found in deploy history",

--- a/messages/deploy.json
+++ b/messages/deploy.json
@@ -27,6 +27,46 @@
     "validateDeployRequestId": "deploy request ID of the validated deployment to run a Quick Deploy",
     "soapDeploy": "deploy metadata with SOAP API instead of REST API"
   },
+    "longDescriptionMetadata": [
+    "A comma-separated list of names of metadata components to deploy to the org.",
+    "If you specify this parameter, don’t specify --manifest or --sourcepath."
+  ],
+  "longDescriptionManifest": [
+    "The complete path for the manifest (package.xml) file that specifies the components to deploy. All child components are included.",
+    "If you specify this parameter, don’t specify --metadata or --sourcepath."
+  ],
+  "longDescriptionSourcePath": [
+    "A comma-separated list of paths to the local source files to deploy. The supplied paths can be to a single file (in which case the operation is applied to only one file) or to a folder (in which case the operation is applied to all metadata types in the directory and its sub-directories).",
+    "If you specify this parameter, don’t specify --manifest or --metadata."
+  ],
+  "longDescriptionValidateDeploy": [
+    "Specifies the ID of a package with recently validated components to run a Quick Deploy. Deploying a validation helps you shorten your deployment time because tests aren’t rerun. If you have a recent successful validation, you can deploy the validated components without running tests. A validation doesn’t save any components in the org. You use a validation only to check the success or failure messages that you would receive with an actual deployment. To validate your components, add the -c | --checkonly flag when you run \"sfdx force:mdapi:deploy\". This flag sets the checkOnly=\"true\" parameter for your deployment. Before deploying a recent validation, ensure that the following requirements are met:",
+    "  1. The components have been validated successfully for the target environment within the last 10 days.",
+    "  2. As part of the validation, Apex tests in the target org have passed.",
+    "  3. Code coverage requirements are met.",
+    "    - If all tests in the org or all local tests are run, overall code coverage is at least 75%, and Apex triggers have some coverage.",
+    "    - If specific tests are run with the RunSpecifiedTests test level, each class and trigger that was deployed is covered by at least 75% individually."
+  ],
+  "longDescriptionIgnoreWarnings": "If a warning occurs and ignoreWarnings is set to true, the success field in DeployMessage is true. When ignoreWarnings is set to false, success is set to false, and the warning is treated like an error.",
+  "longDescriptionIgnoreErrors": "Ignores the deploy errors, and continues with the deploy operation. The default is false. Keep this parameter set to false when deploying to a production org. If set to true, components without errors are deployed, and components with errors are skipped.",
+  "longDescriptionRunTests": "Lists the Apex classes containing the deployment tests to run. Use this parameter when you set --testlevel to RunSpecifiedTests.",
+  "longDescriptionWait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you. ",
+  "longDescriptionTestLevel": [
+    "Specifies which level of deployment tests to run. Valid values are:",
+    "  NoTestRun—No tests are run. This test level applies only to deployments to development environments, such as sandbox, Developer Edition, or trial orgs. This test level is the default for development environments.",
+    "  RunSpecifiedTests—Runs only the tests that you specify in the --runtests option. Code coverage requirements differ from the default coverage requirements when using this test level. Executed tests must comprise a minimum of 75% code coverage for each class and trigger in the deployment package. This coverage is computed for each class and trigger individually and is different than the overall coverage percentage.",
+    "  RunLocalTests—All tests in your org are run, except the ones that originate from installed managed packages. This test level is the default for production deployments that include Apex classes or triggers.",
+    "  RunAllTestsInOrg—All tests in your org are run, including tests of managed packages.",
+    "If you don’t specify a test level, the default behavior depends on the contents of your deployment package. For more information, see “Running Tests in a Deployment” in the Metadata API Developer Guide."
+  ],
+    "longDescriptionCheckOnly": [
+    "Validates the deployed metadata and runs all Apex tests, but prevents the deployment from being saved to the org.",
+    "If you change a field type from Master-Detail to Lookup or vice versa, that change isn’t supported when using the --checkonly parameter to test a deployment (validation). This kind of change isn’t supported for test deployments to avoid the risk of data loss or corruption. If a change that isn’t supported for test deployments is included in a deployment package, the test deployment fails and issues an error.",
+    "If your deployment package changes a field type from Master-Detail to Lookup or vice versa, you can still validate the changes prior to deploying to Production by performing a full deployment to another test Sandbox. A full deployment includes a validation of the changes as part of the deployment process.",
+    "Note: A Metadata API deployment that includes Master-Detail relationships deletes all detail records in the Recycle Bin in the following cases.",
+    "1. For a deployment with a new Master-Detail field, soft delete (send to the Recycle Bin) all detail records before proceeding to deploy the Master-Detail field, or the deployment fails. During the deployment, detail records are permanently deleted from the Recycle Bin and cannot be recovered.",
+    "2. For a deployment that converts a Lookup field relationship to a Master-Detail relationship, detail records must reference a master record or be soft-deleted (sent to the Recycle Bin) for the deployment to succeed. However, a successful deployment permanently deletes any detail records in the Recycle Bin."
+  ],
   "MissingRequiredParam": "Missing one of the following parameters: %s",
   "checkOnlySuccess": "Successfully validated the deployment. %s components deployed and %s tests run.\nUse the --verbose parameter to see detailed output.",
   "MissingDeployId": "No deploy ID was provided or found in deploy history",

--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -35,7 +35,7 @@ export class Deploy extends DeployCommand {
     checkonly: flags.boolean({
       char: 'c',
       description: messages.getMessage('flags.checkonly'),
-      longDescription: messages.getMessage('longDescriptionCheckOnly'),
+      longDescription: messages.getMessage('flagsLong.checkonly'),
     }),
     soapdeploy: flags.boolean({
       default: false,
@@ -46,35 +46,35 @@ export class Deploy extends DeployCommand {
       default: Duration.minutes(Deploy.DEFAULT_SRC_WAIT_MINUTES),
       min: Duration.minutes(0), // wait=0 means deploy is asynchronous
       description: messages.getMessage('flags.wait'),
-      longDescription: messages.getMessage('longDescriptionWait'),
+      longDescription: messages.getMessage('flagsLong.wait'),
     }),
     testlevel: flags.enum({
       char: 'l',
       description: messages.getMessage('flags.testLevel'),
-      longDescription: messages.getMessage('longDescriptionTestLevel'),
+      longDescription: messages.getMessage('flagsLong.testLevel'),
       options: ['NoTestRun', 'RunSpecifiedTests', 'RunLocalTests', 'RunAllTestsInOrg'],
       default: 'NoTestRun',
     }),
     runtests: flags.array({
       char: 'r',
       description: messages.getMessage('flags.runTests'),
-      longDescription: messages.getMessage('longDescriptionRunTests'),
+      longDescription: messages.getMessage('flagsLong.runTests'),
       default: [],
     }),
     ignoreerrors: flags.boolean({
       char: 'o',
       description: messages.getMessage('flags.ignoreErrors'),
-      longDescription: messages.getMessage('longDescriptionIgnoreErrors'),
+      longDescription: messages.getMessage('flagsLong.ignoreErrors'),
     }),
     ignorewarnings: flags.boolean({
       char: 'g',
       description: messages.getMessage('flags.ignoreWarnings'),
-      longDescription: messages.getMessage('longDescriptionIgnoreWarnings'),
+      longDescription: messages.getMessage('flagsLong.ignoreWarnings'),
     }),
     validateddeployrequestid: flags.id({
       char: 'q',
       description: messages.getMessage('flags.validateDeployRequestId'),
-      longDescription: messages.getMessage('longDescriptionValidateDeploy'),
+      longDescription: messages.getMessage('flagsLong.validateDeployRequestId'),
       exclusive: [
         'manifest',
         'metadata',
@@ -92,19 +92,19 @@ export class Deploy extends DeployCommand {
     metadata: flags.array({
       char: 'm',
       description: messages.getMessage('flags.metadata'),
-      longDescription: messages.getMessage('longDescriptionMetadata'),
+      longDescription: messages.getMessage('flagsLong.metadata'),
       exclusive: ['manifest', 'sourcepath'],
     }),
     sourcepath: flags.array({
       char: 'p',
       description: messages.getMessage('flags.sourcePath'),
-      longDescription: messages.getMessage('longDescriptionSourcePath'),
+      longDescription: messages.getMessage('flagsLong.sourcePath'),
       exclusive: ['manifest', 'metadata'],
     }),
     manifest: flags.filepath({
       char: 'x',
       description: messages.getMessage('flags.manifest'),
-      longDescription: messages.getMessage('longDescriptionManifest'),
+      longDescription: messages.getMessage('flagsLong.manifest'),
       exclusive: ['metadata', 'sourcepath'],
     }),
   };

--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -35,6 +35,7 @@ export class Deploy extends DeployCommand {
     checkonly: flags.boolean({
       char: 'c',
       description: messages.getMessage('flags.checkonly'),
+      longDescription: messages.getMessage('longDescriptionCheckOnly'),
     }),
     soapdeploy: flags.boolean({
       default: false,
@@ -45,29 +46,35 @@ export class Deploy extends DeployCommand {
       default: Duration.minutes(Deploy.DEFAULT_SRC_WAIT_MINUTES),
       min: Duration.minutes(0), // wait=0 means deploy is asynchronous
       description: messages.getMessage('flags.wait'),
+      longDescription: messages.getMessage('longDescriptionWait'),
     }),
     testlevel: flags.enum({
       char: 'l',
       description: messages.getMessage('flags.testLevel'),
+      longDescription: messages.getMessage('longDescriptionTestLevel'),
       options: ['NoTestRun', 'RunSpecifiedTests', 'RunLocalTests', 'RunAllTestsInOrg'],
       default: 'NoTestRun',
     }),
     runtests: flags.array({
       char: 'r',
       description: messages.getMessage('flags.runTests'),
+      longDescription: messages.getMessage('longDescriptionRunTests'),
       default: [],
     }),
     ignoreerrors: flags.boolean({
       char: 'o',
       description: messages.getMessage('flags.ignoreErrors'),
+      longDescription: messages.getMessage('longDescriptionIgnoreErrors'),
     }),
     ignorewarnings: flags.boolean({
       char: 'g',
       description: messages.getMessage('flags.ignoreWarnings'),
+      longDescription: messages.getMessage('longDescriptionIgnoreWarnings'),
     }),
     validateddeployrequestid: flags.id({
       char: 'q',
       description: messages.getMessage('flags.validateDeployRequestId'),
+      longDescription: messages.getMessage('longDescriptionValidateDeploy'),
       exclusive: [
         'manifest',
         'metadata',
@@ -85,16 +92,19 @@ export class Deploy extends DeployCommand {
     metadata: flags.array({
       char: 'm',
       description: messages.getMessage('flags.metadata'),
+      longDescription: messages.getMessage('longDescriptionMetadata'),
       exclusive: ['manifest', 'sourcepath'],
     }),
     sourcepath: flags.array({
       char: 'p',
       description: messages.getMessage('flags.sourcePath'),
+      longDescription: messages.getMessage('longDescriptionSourcePath'),
       exclusive: ['manifest', 'metadata'],
     }),
     manifest: flags.filepath({
       char: 'x',
       description: messages.getMessage('flags.manifest'),
+      longDescription: messages.getMessage('longDescriptionManifest'),
       exclusive: ['metadata', 'sourcepath'],
     }),
   };


### PR DESCRIPTION
### What does this PR do?

puts back the parameter long descriptions for the force:source:deploy command.  

### What issues does this PR fix or reference?

@W-9842098@