### PR TITLE
fix: find server errors and display them with FileResponse errors

### DIFF
--- a/test/formatters/deployResultFormatter.test.ts
+++ b/test/formatters/deployResultFormatter.test.ts
@@ -10,7 +10,7 @@ import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { Logger } from '@salesforce/core';
 import { UX } from '@salesforce/command';
-import { FileResponse } from '@salesforce/source-deploy-retrieve';
+import { DeployMessage, FileResponse } from '@salesforce/source-deploy-retrieve';
 import { stubInterface } from '@salesforce/ts-sinon';
 import { getDeployResult } from '../commands/source/deployResponses';
 import { DeployCommandResult, DeployResultFormatter } from '../../src/formatters/deployResultFormatter';
@@ -96,41 +96,50 @@ describe('DeployResultFormatter', () => {
       expect(styledHeaderStub.calledOnce).to.equal(true);
       expect(logStub.calledTwice).to.equal(true);
       expect(tableStub.called).to.equal(true);
-      expect(styledHeaderStub.firstCall.args[0]).to.contain('Component Failures [1]');
+      expect(styledHeaderStub.args[0][0]).to.include('Component Failures [2]');
       const fileResponses = deployResultFailure.getFileResponses();
       resolveExpectedPaths(fileResponses);
-      expect(tableStub.firstCall.args[0]).to.deep.equal(fileResponses);
+      const mutatedObject = Object.assign(deployResultFailure.response.details.componentFailures, {
+        error: (deployResultFailure.response.details.componentFailures as DeployMessage).problem,
+      });
+
+      const tableData = [...fileResponses, mutatedObject];
+
+      expect(tableStub.firstCall.args[0]).to.deep.equal(tableData);
     });
 
     it('should output as expected for a test failure with verbose', async () => {
       const formatter = new DeployResultFormatter(logger, ux, { verbose: true }, deployResultTestFailure);
       formatter.display();
-      expect(styledHeaderStub.calledTwice).to.equal(true);
-      expect(logStub.callCount).to.equal(5);
-      expect(tableStub.calledTwice).to.equal(true);
-      expect(styledHeaderStub.firstCall.args[0]).to.contain('Test Failures [1]');
-      expect(styledHeaderStub.secondCall.args[0]).to.contain('Apex Code Coverage');
+      expect(styledHeaderStub.calledThrice).to.equal(true);
+      expect(logStub.callCount).to.equal(7);
+      expect(tableStub.calledThrice).to.equal(true);
+      expect(styledHeaderStub.args[0][0]).to.include('Component Failures [1]');
+      expect(styledHeaderStub.args[1][0]).to.include('Test Failures [1]');
+      expect(styledHeaderStub.args[2][0]).to.include('Apex Code Coverage');
     });
 
     it('should output as expected for passing tests with verbose', async () => {
       const formatter = new DeployResultFormatter(logger, ux, { verbose: true }, deployResultTestSuccess);
       formatter.display();
-      expect(styledHeaderStub.calledTwice).to.equal(true);
-      expect(logStub.callCount).to.equal(5);
-      expect(tableStub.calledTwice).to.equal(true);
-      expect(styledHeaderStub.firstCall.args[0]).to.contain('Test Success [1]');
-      expect(styledHeaderStub.secondCall.args[0]).to.contain('Apex Code Coverage');
+      expect(styledHeaderStub.calledThrice).to.equal(true);
+      expect(logStub.callCount).to.equal(7);
+      expect(tableStub.calledThrice).to.equal(true);
+      expect(styledHeaderStub.args[0][0]).to.include('Component Failures [1]');
+      expect(styledHeaderStub.args[1][0]).to.include('Test Success [1]');
+      expect(styledHeaderStub.args[2][0]).to.include('Apex Code Coverage');
     });
 
     it('should output as expected for passing and failing tests with verbose', async () => {
       const formatter = new DeployResultFormatter(logger, ux, { verbose: true }, deployResultTestSuccessAndFailure);
       formatter.display();
-      expect(styledHeaderStub.callCount).to.equal(3);
-      expect(logStub.callCount).to.equal(6);
-      expect(tableStub.callCount).to.equal(3);
-      expect(styledHeaderStub.firstCall.args[0]).to.contain('Test Failures [2]');
-      expect(styledHeaderStub.secondCall.args[0]).to.contain('Test Success [1]');
-      expect(styledHeaderStub.thirdCall.args[0]).to.contain('Apex Code Coverage');
+      expect(styledHeaderStub.callCount).to.equal(4);
+      expect(logStub.callCount).to.equal(8);
+      expect(tableStub.callCount).to.equal(4);
+      expect(styledHeaderStub.args[0][0]).to.include('Component Failures [1]');
+      expect(styledHeaderStub.args[1][0]).to.include('Test Failures [2]');
+      expect(styledHeaderStub.args[2][0]).to.include('Test Success [1]');
+      expect(styledHeaderStub.args[3][0]).to.include('Apex Code Coverage');
     });
   });
 });

--- a/test/formatters/deployResultFormatter.test.ts
+++ b/test/formatters/deployResultFormatter.test.ts
@@ -10,7 +10,7 @@ import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { Logger } from '@salesforce/core';
 import { UX } from '@salesforce/command';
-import { DeployMessage, FileResponse } from '@salesforce/source-deploy-retrieve';
+import { FileResponse } from '@salesforce/source-deploy-retrieve';
 import { stubInterface } from '@salesforce/ts-sinon';
 import { getDeployResult } from '../commands/source/deployResponses';
 import { DeployCommandResult, DeployResultFormatter } from '../../src/formatters/deployResultFormatter';
@@ -90,22 +90,16 @@ describe('DeployResultFormatter', () => {
       expect(tableStub.firstCall.args[0]).to.deep.equal(fileResponses);
     });
 
-    it('should output as expected for a failure', async () => {
+    it('should output as expected for a failure and exclude duplicate information', async () => {
       const formatter = new DeployResultFormatter(logger, ux, {}, deployResultFailure);
       formatter.display();
       expect(styledHeaderStub.calledOnce).to.equal(true);
       expect(logStub.calledTwice).to.equal(true);
       expect(tableStub.called).to.equal(true);
-      expect(styledHeaderStub.args[0][0]).to.include('Component Failures [2]');
+      expect(styledHeaderStub.args[0][0]).to.include('Component Failures [1]');
       const fileResponses = deployResultFailure.getFileResponses();
       resolveExpectedPaths(fileResponses);
-      const mutatedObject = Object.assign(deployResultFailure.response.details.componentFailures, {
-        error: (deployResultFailure.response.details.componentFailures as DeployMessage).problem,
-      });
-
-      const tableData = [...fileResponses, mutatedObject];
-
-      expect(tableStub.firstCall.args[0]).to.deep.equal(tableData);
+      expect(tableStub.firstCall.args[0]).to.deep.equal(fileResponses);
     });
 
     it('should output as expected for a test failure with verbose', async () => {


### PR DESCRIPTION
### What does this PR do?
checks the server response for other issues not present in the `getFileResponse()` method from SDR and displays them alongside other deployment issues.

### What issues does this PR fix or reference?
@W-9816657@ https://github.com/forcedotcom/cli/issues/1180

OLD
```
 ➜  sfdx force:source:deploy -m CustomField:Account.Name 
*** Deploying with SOAP API ***
Deploy ID: 0AfJ000001m2PoWKAU
SOURCE PROGRESS | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | 0/1 Components
ERROR running force:source:deploy:  Deploy failed.
```

NEW
```
 ➜  sfdx force:source:deploy -m CustomField:Account.Name 
*** Deploying with SOAP API ***
Deploy ID: 0AfJ000001m1diRKAQ
SOURCE PROGRESS | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | 0/1 Components

=== Component Failures [1]
Type   Name             Problem
─────  ───────────────  ──────────────────
Error  Account.NameNew  Not in package.xml
```