### PR TITLE
fix: add back missing long parameter descriptions for some force:source commands

### DIFF
--- a/messages/cancel.json
+++ b/messages/cancel.json
@@ -7,5 +7,8 @@
   "flags": {
     "wait": "wait time for command to finish in minutes",
     "jobid": "job ID of the deployment you want to cancel; defaults to your most recent CLI deployment if not specified"
+  },
+  "flagsLong": {
+    "wait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you. "
   }
 }

--- a/messages/convert.json
+++ b/messages/convert.json
@@ -12,7 +12,7 @@
     "sourcepath": "comma-separated list of paths to the local source files to convert",
     "metadata": "comma-separated list of metadata component names to convert"
   },
-    "flagsLong": {
+  "flagsLong": {
     "manifest": [
       "The complete path to the manifest (package.xml) file that specifies the metadata types to convert.",
       "If you specify this parameter, don’t specify --metadata or --sourcepath."

--- a/messages/convert.json
+++ b/messages/convert.json
@@ -12,6 +12,16 @@
     "sourcepath": "comma-separated list of paths to the local source files to convert",
     "metadata": "comma-separated list of metadata component names to convert"
   },
+    "flagsLong": {
+    "manifest": [
+      "The complete path to the manifest (package.xml) file that specifies the metadata types to convert.",
+      "If you specify this parameter, don’t specify --metadata or --sourcepath."
+    ],
+    "sourcepath": [
+      "A comma-separated list of paths to the local source files to convert. The supplied paths can be to a single file (in which case the operation is applied to only one file) or to a folder (in which case the operation is applied to all metadata types in the directory and its sub-directories).",
+      "If you specify this parameter, don’t specify --manifest or --metadata."
+    ]
+  },
   "success": "Source was successfully converted to Metadata API format and written to the location: %s",
   "convertFailed": "Failed to convert source"
 }

--- a/messages/delete.json
+++ b/messages/delete.json
@@ -9,10 +9,33 @@
     "checkonly": "validate delete command but do not delete from the org or delete files locally",
     "testLevel": "deployment testing level",
     "runTests": "tests to run if --testlevel RunSpecifiedTests",
-    "verbose": "verbose output of delete result",
-
-    "checkonlyLong": "Validates the deleted metadata and runs all Apex tests, but prevents the deletion from being saved to the org. \nIf you change a field type from Master-Detail to Lookup or vice versa, that change isn’t supported when using the --checkonly parameter to test a deletion (validation). This kind of change isn’t supported for test deletions to avoid the risk of data loss or corruption. If a change that isn’t supported for test deletions is included in a deletion package, the test deletion fails and issues an error.\nIf your deletion package changes a field type from Master-Detail to Lookup or vice versa, you can still validate the changes prior to deploying to Production by performing a full deletion to another test Sandbox. A full deletion includes a validation of the changes as part of the deletion process.\nNote: A Metadata API deletion that includes Master-Detail relationships deletes all detail records in the Recycle Bin in the following cases.\n1. For a deletion with a new Master-Detail field, soft delete (send to the Recycle Bin) all detail records before proceeding to delete the Master-Detail field, or the deletion fails. During the deletion, detail records are permanently deleted from the Recycle Bin and cannot be recovered.\n2. For a deletion that converts a Lookup field relationship to a Master-Detail relationship, detail records must reference a master record or be soft-deleted (sent to the Recycle Bin) for the deletion to succeed. However, a successful deletion permanently deletes any detail records in the Recycle Bin.",
-    "sourcepathLong": "A comma-separated list of paths to the local metadata to delete. The supplied paths can be a single file (in which case the operation is applied to only one file) or a folder (in which case the operation is applied to all metadata types in the directory and its sub-directories).\nIf you specify this parameter, don’t specify --manifest or --metadata."
+    "verbose": "verbose output of delete result"
+  },
+  "flagsLong": {
+    "checkonly": [
+      "Validates the deleted metadata and runs all Apex tests, but prevents the deletion from being saved to the org. ",
+      "If you change a field type from Master-Detail to Lookup or vice versa, that change isn’t supported when using the --checkonly parameter to test a deletion (validation). This kind of change isn’t supported for test deletions to avoid the risk of data loss or corruption. If a change that isn’t supported for test deletions is included in a deletion package, the test deletion fails and issues an error.",
+      "If your deletion package changes a field type from Master-Detail to Lookup or vice versa, you can still validate the changes prior to deploying to Production by performing a full deletion to another test Sandbox. A full deletion includes a validation of the changes as part of the deletion process.",
+      "Note: A Metadata API deletion that includes Master-Detail relationships deletes all detail records in the Recycle Bin in the following cases.",
+      "1. For a deletion with a new Master-Detail field, soft delete (send to the Recycle Bin) all detail records before proceeding to delete the Master-Detail field, or the deletion fails. During the deletion, detail records are permanently deleted from the Recycle Bin and cannot be recovered.",
+      "2. For a deletion that converts a Lookup field relationship to a Master-Detail relationship, detail records must reference a master record or be soft-deleted (sent to the Recycle Bin) for the deletion to succeed. However, a successful deletion permanently deletes any detail records in the Recycle Bin."
+    ],
+    "metadata": [
+      "A comma-separated list of names of metadata components to delete from your project and your org.",
+      "If you specify this parameter, don’t specify --sourcepath."
+    ],
+    "sourcepath": [
+      "A comma-separated list of paths to the local metadata to delete. The supplied paths can be a single file (in which case the operation is applied to only one file) or a folder (in which case the operation is applied to all metadata types in the directory and its sub-directories).",
+      "If you specify this parameter, don’t specify --metadata."
+    ],
+    "wait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you.",
+    "testLevel": [
+      "Specifies which level of deployment tests to run. Valid values are:",
+      "NoTestRun—No tests are run. This test level applies only to deployments to development environments, such as sandbox, Developer Edition, or trial orgs. This test level is the default for development environments.",
+      "RunLocalTests—All tests in your org are run, except the ones that originate from installed managed packages. This test level is the default for production deployments that include Apex classes or triggers.",
+      "RunAllTestsInOrg—All tests in your org are run, including tests of managed packages.",
+      "If you don’t specify a test level, the default behavior depends on the contents of your deployment package. For more information, see “Running Tests in a Deployment” in the Metadata API Developer Guide."
+    ]
   },
   "prompt": "This operation will delete the following files on your computer and in your org: \n%s\n\nAre you sure you want to proceed (y/n)?"
 }

--- a/messages/report.json
+++ b/messages/report.json
@@ -16,7 +16,7 @@
     "wait": "wait time for command to finish in minutes",
     "verbose": "verbose output of deploy result"
   },
-    "flagsLong": {
+  "flagsLong": {
     "wait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you. ",
     "jobid": "The job ID (asyncId) of the deployment you want to check. If not specified, the default value is the ID of the most recent metadata deployment you ran using Salesforce CLI. Use with -w to resume waiting."
   },

--- a/messages/report.json
+++ b/messages/report.json
@@ -16,5 +16,9 @@
     "wait": "wait time for command to finish in minutes",
     "verbose": "verbose output of deploy result"
   },
+    "flagsLong": {
+    "wait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you. ",
+    "jobid": "The job ID (asyncId) of the deployment you want to check. If not specified, the default value is the ID of the most recent metadata deployment you ran using Salesforce CLI. Use with -w to resume waiting."
+  },
   "mdapiDeployFailed": "The metadata deploy operation failed."
 }

--- a/messages/retrieve.json
+++ b/messages/retrieve.json
@@ -20,6 +20,21 @@
     "packagename": "a comma-separated list of packages to retrieve",
     "verbose": "verbose output of retrieve result"
   },
+   "flagsLong": {
+    "wait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you.",
+    "manifest": [
+      "The complete path for the manifest (package.xml) file that specifies the components to retrieve.",
+      "If you specify this parameter, don’t specify --metadata or --sourcepath."
+    ],
+    "metadata": [
+      "A comma-separated list of names of metadata components to retrieve from the org.",
+      "If you specify this parameter, don’t specify --manifest or --sourcepath."
+    ],
+    "sourcePath": [
+      "A comma-separated list of file paths for source to retrieve from the org. The supplied paths can be to a single file (in which case the operation is applied to only one file) or to a folder (in which case the operation is applied to all source files in the directory and its sub-directories).",
+      "If you specify this parameter, don’t specify --manifest or --metadata."
+    ]
+  },
   "SourceRetrieveError": "Could not retrieve files in the sourcepath%s",
   "retrieveTimeout": "Your retrieve request did not complete within the specified wait time [%s minutes]. Try again with a longer wait time.",
   "retrievedSourceHeader": "Retrieved Source",

--- a/messages/retrieve.json
+++ b/messages/retrieve.json
@@ -20,7 +20,7 @@
     "packagename": "a comma-separated list of packages to retrieve",
     "verbose": "verbose output of retrieve result"
   },
-   "flagsLong": {
+  "flagsLong": {
     "wait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you.",
     "manifest": [
       "The complete path for the manifest (package.xml) file that specifies the components to retrieve.",

--- a/src/commands/force/source/convert.ts
+++ b/src/commands/force/source/convert.ts
@@ -39,10 +39,12 @@ export class Convert extends SourceCommand {
     manifest: flags.string({
       char: 'x',
       description: messages.getMessage('flags.manifest'),
+      longDescription: messages.getMessage('flagsLong.manifest'),
     }),
     sourcepath: flags.array({
       char: 'p',
       description: messages.getMessage('flags.sourcepath'),
+      longDescription: messages.getMessage('flagsLong.sourcepath'),
       exclusive: ['manifest', 'metadata'],
     }),
     metadata: flags.array({

--- a/src/commands/force/source/delete.ts
+++ b/src/commands/force/source/delete.ts
@@ -33,17 +33,19 @@ export class Delete extends DeployCommand {
     checkonly: flags.boolean({
       char: 'c',
       description: messages.getMessage('flags.checkonly'),
-      longDescription: messages.getMessage('flags.checkonlyLong'),
+      longDescription: messages.getMessage('flagsLong.checkonly'),
     }),
     wait: flags.minutes({
       char: 'w',
       default: Duration.minutes(Delete.DEFAULT_SRC_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
+      longDescription: messages.getMessage('flagsLong.wait'),
     }),
     testlevel: flags.enum({
       char: 'l',
       description: messages.getMessage('flags.testLevel'),
+      longDescription: messages.getMessage('flagsLong.testLevel'),
       options: ['NoTestRun', 'RunLocalTests', 'RunAllTestsInOrg'],
       default: 'NoTestRun',
     }),
@@ -54,12 +56,13 @@ export class Delete extends DeployCommand {
     metadata: flags.array({
       char: 'm',
       description: messages.getMessage('flags.metadata'),
+      longDescription: messages.getMessage('flagsLong.metadata'),
       exclusive: ['manifest', 'sourcepath'],
     }),
     sourcepath: flags.array({
       char: 'p',
       description: messages.getMessage('flags.sourcepath'),
-      longDescription: messages.getMessage('flags.sourcepathLong'),
+      longDescription: messages.getMessage('flagsLong.sourcepath'),
       exclusive: ['manifest', 'metadata'],
     }),
     verbose: flags.builtin({

--- a/src/commands/force/source/deploy/cancel.ts
+++ b/src/commands/force/source/deploy/cancel.ts
@@ -30,7 +30,7 @@ export class Cancel extends DeployCommand {
       default: Duration.minutes(DeployCommand.DEFAULT_SRC_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
-      longDescription: messages.getMessage('flagsLong.wait')
+      longDescription: messages.getMessage('flagsLong.wait'),
     }),
     jobid: flags.id({
       char: 'i',

--- a/src/commands/force/source/deploy/cancel.ts
+++ b/src/commands/force/source/deploy/cancel.ts
@@ -30,6 +30,7 @@ export class Cancel extends DeployCommand {
       default: Duration.minutes(DeployCommand.DEFAULT_SRC_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
+      longDescription: messages.getMessage('flagsLong.wait')
     }),
     jobid: flags.id({
       char: 'i',

--- a/src/commands/force/source/deploy/report.ts
+++ b/src/commands/force/source/deploy/report.ts
@@ -33,12 +33,12 @@ export class Report extends DeployCommand {
       default: Duration.minutes(DeployCommand.DEFAULT_SRC_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
-      longDescription: messages.getMessage('flagsLong.wait')
+      longDescription: messages.getMessage('flagsLong.wait'),
     }),
     jobid: flags.id({
       char: 'i',
       description: messages.getMessage('flags.jobid'),
-      longDescription: messages.getMessage('flagsLong.jobid')
+      longDescription: messages.getMessage('flagsLong.jobid'),
     }),
     verbose: flags.builtin({
       description: messages.getMessage('flags.verbose'),

--- a/src/commands/force/source/deploy/report.ts
+++ b/src/commands/force/source/deploy/report.ts
@@ -33,10 +33,12 @@ export class Report extends DeployCommand {
       default: Duration.minutes(DeployCommand.DEFAULT_SRC_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
+      longDescription: messages.getMessage('flagsLong.wait')
     }),
     jobid: flags.id({
       char: 'i',
       description: messages.getMessage('flags.jobid'),
+      longDescription: messages.getMessage('flagsLong.jobid')
     }),
     verbose: flags.builtin({
       description: messages.getMessage('flags.verbose'),

--- a/src/commands/force/source/retrieve.ts
+++ b/src/commands/force/source/retrieve.ts
@@ -37,6 +37,7 @@ export class Retrieve extends SourceCommand {
     sourcepath: flags.array({
       char: 'p',
       description: messages.getMessage('flags.sourcePath'),
+      longDescription: messages.getMessage('flagsLong.sourcePath'),
       exclusive: ['manifest', 'metadata'],
     }),
     wait: flags.minutes({
@@ -44,15 +45,18 @@ export class Retrieve extends SourceCommand {
       default: Duration.minutes(SourceCommand.DEFAULT_SRC_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
+      longDescription: messages.getMessage('flagsLong.wait'),
     }),
     manifest: flags.filepath({
       char: 'x',
       description: messages.getMessage('flags.manifest'),
+      longDescription: messages.getMessage('flagsLong.manifest'),
       exclusive: ['metadata', 'sourcepath'],
     }),
     metadata: flags.array({
       char: 'm',
       description: messages.getMessage('flags.metadata'),
+      longDescription: messages.getMessage('flagsLong.metadata'),
       exclusive: ['manifest', 'sourcepath'],
     }),
     packagenames: flags.array({


### PR DESCRIPTION
### What does this PR do?
Puts back the long parameter descriptions that were lost when the force:source SDR commands were moved to their own plugin from toolbelt.

### What issues does this PR fix or reference?

@W-9842098@