### PR TITLE
fix: handle a corrupt stash.json file

### DIFF
--- a/messages/deploy.json
+++ b/messages/deploy.json
@@ -76,6 +76,7 @@
   "MissingRequiredParam": "Missing one of the following parameters: %s",
   "checkOnlySuccess": "Successfully validated the deployment. %s components deployed and %s tests run.\nUse the --verbose parameter to see detailed output.",
   "MissingDeployId": "No deploy ID was provided or found in deploy history",
+  "InvalidStashFile": "Invalid deployment stash file encountered. File has been renamed to: %s.  Please specify a deploy ID using the command parameter.",
   "deployCanceled": "The deployment has been canceled by %s",
   "deployFailed": "Deploy failed.",
   "asyncDeployQueued": "Deploy has been queued.",

--- a/src/deployCommand.ts
+++ b/src/deployCommand.ts
@@ -67,7 +67,12 @@ export abstract class DeployCommand extends SourceCommand {
           const stashFilePath = stash.getPath();
           const corruptFilePath = `${stashFilePath}_corrupted_${Date.now()}`;
           fs.renameSync(stashFilePath, corruptFilePath);
-          throw SfdxError.create('@salesforce/plugin-source', 'deploy', 'InvalidStashFile', [corruptFilePath]);
+          const invalidStashErr = SfdxError.create('@salesforce/plugin-source', 'deploy', 'InvalidStashFile', [
+            corruptFilePath,
+          ]);
+          invalidStashErr.message = `${invalidStashErr.message}\n${error.message}`;
+          invalidStashErr.stack = `${invalidStashErr.stack}\nDue to:\n${error.stack}`;
+          throw invalidStashErr;
         }
         if (error.code === 'ENOENT') {
           throw SfdxError.create('@salesforce/plugin-source', 'deploy', 'MissingDeployId');

--- a/src/deployCommand.ts
+++ b/src/deployCommand.ts
@@ -5,11 +5,17 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import * as fs from 'fs';
 import { ComponentSet, DeployResult, MetadataApiDeployStatus } from '@salesforce/source-deploy-retrieve';
 import { ConfigAggregator, ConfigFile, PollingClient, SfdxError, StatusResult } from '@salesforce/core';
 import { AnyJson, asString, getBoolean } from '@salesforce/ts-types';
 import { Duration, once } from '@salesforce/kit';
 import { SourceCommand } from './sourceCommand';
+
+interface StashFile {
+  isGlobal: boolean;
+  filename: string;
+}
 
 export abstract class DeployCommand extends SourceCommand {
   protected static readonly STASH_KEY = 'SOURCE_DEPLOY';
@@ -45,17 +51,24 @@ export abstract class DeployCommand extends SourceCommand {
   }
 
   protected resolveDeployId(id: string): string {
+    let stash: ConfigFile<StashFile>;
     if (id) {
       return id;
     } else {
       try {
-        const stash = this.getStash();
+        stash = this.getStash();
         stash.readSync(true);
         const deployId = asString((stash.get(DeployCommand.STASH_KEY) as { jobid: string }).jobid);
         this.logger.debug(`Using deploy ID: ${deployId} from ${stash.getPath()}`);
         return deployId;
       } catch (err: unknown) {
         const error = err as Error & { code: string };
+        if (error.name === 'JsonParseError') {
+          const stashFilePath = stash.getPath();
+          const corruptFilePath = `${stashFilePath}_corrupted_${Date.now()}`;
+          fs.renameSync(stashFilePath, corruptFilePath);
+          throw SfdxError.create('@salesforce/plugin-source', 'deploy', 'InvalidStashFile', [corruptFilePath]);
+        }
         if (error.code === 'ENOENT') {
           throw SfdxError.create('@salesforce/plugin-source', 'deploy', 'MissingDeployId');
         }
@@ -106,7 +119,7 @@ export abstract class DeployCommand extends SourceCommand {
     return pollingClient.subscribe() as unknown as Promise<DeployResult>;
   }
 
-  private getStash(): ConfigFile<{ isGlobal: true; filename: 'stash.json' }> {
+  private getStash(): ConfigFile<StashFile> {
     return new ConfigFile({ isGlobal: true, filename: 'stash.json' });
   }
 }


### PR DESCRIPTION
### What does this PR do?
When a JsonParseError is thrown while reading `stash.json` for the deploy ID, the error is now caught, the file is renamed to stash.json_corrupted_<timestamp> and an error message is displayed that shows the parse failure and the location of the renamed stash.json so users can inspect the file, or possibly rebuild a valid file from the corrupt version.

### What issues does this PR fix or reference?
@W-7837761@

Testing:
1. change stash.json to be invalid json
2. delete stash.json
3. change stash.json to be empty

In all cases an error should be thrown.  In 1 & 3 the stash.json file will be renamed so running the command again will not result in the same behaviour.