### PR TITLE
fix: add back missing help for listmetadata/describemetadata

### DIFF
--- a/messages/md.describe.json
+++ b/messages/md.describe.json
@@ -1,5 +1,5 @@
 {
-  "description": "display the metadata types enabled for your org",
+  "description": "display details about the metadata types enabled for your org\nUse this information to identify the syntax needed for a <name> element in package.xml. The most recent API version is the default, or you can specify an older version.\n\nThe default target username is the admin user for the default scratch org. The username must have the Modify All Data permission or the Modify Metadata permission (Beta). For more information about permissions, see Salesforce Help.",
   "examples": [
     "$ sfdx force:mdapi:describemetadata -a 43.0",
     "$ sfdx force:mdapi:describemetadata -u me@example.com",

--- a/messages/md.list.json
+++ b/messages/md.list.json
@@ -1,5 +1,5 @@
 {
-  "description": "display properties of metadata components of a specified type",
+  "description": "display properties of metadata components of a specified type\nThis command is useful when you want to identify individual components in your manifest file or if you want a high-level view of particular components in your organization. For example, you could use this target to return a list of names of all Layout components in your org, then use this information in a retrieve operation that returns a subset of these components.",
   "examples": [
     "$ sfdx force:mdapi:listmetadata -m CustomObject",
     "$ sfdx force:mdapi:listmetadata -m CustomObject -a 43.0",


### PR DESCRIPTION
### What does this PR do?

Adds back a bit of missing command help after listmetadata and describemetadata were moved to plugin-source from toolbelt.

### What issues does this PR fix or reference?

@W-10165523@