### PR TITLE
fix: add mdapi:deploy:cancel command, refactor base classes to support MDAPI and SOURCE stash keys

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,5 +1,20 @@
 [
   {
+    "command": "force:mdapi:deploy:cancel",
+    "plugin": "@salesforce/plugin-source",
+    "flags": ["apiversion", "jobid", "json", "loglevel", "targetusername", "wait"]
+  },
+  {
+    "command": "force:mdapi:describemetadata",
+    "plugin": "@salesforce/plugin-source",
+    "flags": ["apiversion", "filterknown", "json", "loglevel", "resultfile", "targetusername"]
+  },
+  {
+    "command": "force:mdapi:listmetadata",
+    "plugin": "@salesforce/plugin-source",
+    "flags": ["apiversion", "folder", "json", "loglevel", "metadatatype", "resultfile", "targetusername"]
+  },
+  {
     "command": "force:source:beta:pull",
     "plugin": "@salesforce/plugin-source",
     "flags": ["apiversion", "forceoverwrite", "json", "loglevel", "targetusername", "wait"]
@@ -105,15 +120,5 @@
       "verbose",
       "wait"
     ]
-  },
-  {
-    "command": "force:mdapi:listmetadata",
-    "plugin": "@salesforce/plugin-source",
-    "flags": ["apiversion", "json", "loglevel", "resultfile", "targetusername", "metadatatype", "folder"]
-  },
-  {
-    "command": "force:mdapi:describemetadata",
-    "plugin": "@salesforce/plugin-source",
-    "flags": ["apiversion", "json", "loglevel", "resultfile", "targetusername", "filterknown"]
   }
 ]

--- a/messages/cancel.json
+++ b/messages/cancel.json
@@ -10,5 +10,6 @@
   },
   "flagsLong": {
     "wait": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you. "
-  }
+  },
+  "CancelFailed": "The cancel command failed due to: %s"
 }

--- a/messages/deploy.json
+++ b/messages/deploy.json
@@ -81,5 +81,6 @@
   "deployFailed": "Deploy failed.",
   "asyncDeployQueued": "Deploy has been queued.",
   "asyncDeployCancel": "Run sfdx force:source:deploy:cancel -i %s to cancel the deploy.",
-  "asyncDeployReport": "Run sfdx force:source:deploy:report -i %s to get the latest status."
+  "asyncDeployReport": "Run sfdx force:source:deploy:report -i %s to get the latest status.",
+  "invalidDeployId": "The provided ID is invalid, deploy IDs must start with '0Af'"
 }

--- a/messages/md.cancel.json
+++ b/messages/md.cancel.json
@@ -9,12 +9,12 @@
 
   "examples": [
     "Deploy a directory of files to the org",
-    "$ sfdx force:mdapi:deploy -d <directory>",
+    "  $ sfdx force:mdapi:deploy -d <directory>",
     "Now cancel this deployment and wait two minutes",
-    "$ sfdx force:mdapi:deploy:cancel -w 2",
+    "  $ sfdx force:mdapi:deploy:cancel -w 2",
     "If you have multiple deployments in progress and want to cancel a specific one, specify the job ID",
-    "$ sfdx force:mdapi:deploy:cancel -i <jobid>",
+    "  $ sfdx force:mdapi:deploy:cancel -i <jobid>",
     "Check the status of the cancel job",
-    "$ sfdx force:mdapi:deploy:report"
+    "  $ sfdx force:mdapi:deploy:report"
   ]
 }

--- a/messages/md.cancel.json
+++ b/messages/md.cancel.json
@@ -1,0 +1,20 @@
+{
+  "description": "cancel a metadata deployment \n Use this command to cancel a specified asynchronous metadata deployment. You can also specify a wait time (in minutes) to check for updates to the canceled deploy status.",
+  "longDescription": "Cancels an asynchronous metadata deployment.",
+  "flags": {
+    "wait": "wait time for command to finish in minutes",
+    "waitLong": "Number of minutes to wait for the command to complete and display results to the terminal window. If the command continues to run after the wait period, the CLI returns control of the terminal window to you. The default is 33 minutes.",
+    "jobid": "job ID of the deployment you want to cancel; defaults to your most recent CLI deployment if not specified"
+  },
+
+  "examples": [
+    "Deploy a directory of files to the org",
+    "$ sfdx force:mdapi:deploy -d <directory>",
+    "Now cancel this deployment and wait two minutes",
+    "$ sfdx force:mdapi:deploy:cancel -w 2",
+    "If you have multiple deployments in progress and want to cancel a specific one, specify the job ID",
+    "$ sfdx force:mdapi:deploy:cancel -i <jobid>",
+    "Check the status of the cancel job",
+    "$ sfdx force:mdapi:deploy:report"
+  ]
+}

--- a/src/commands/force/mdapi/deploy/cancel.ts
+++ b/src/commands/force/mdapi/deploy/cancel.ts
@@ -9,7 +9,6 @@ import * as os from 'os';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
-import { getString } from '@salesforce/ts-types';
 import { RequestStatus } from '@salesforce/source-deploy-retrieve';
 import { DeployCommand } from '../../../../deployCommand';
 import {
@@ -56,7 +55,7 @@ export class Cancel extends DeployCommand {
   }
 
   protected resolveSuccess(): void {
-    const status = getString(this.deployResult, 'response.status');
+    const status = this.deployResult.response.status;
     if (status !== RequestStatus.Canceled) {
       this.setExitCode(1);
     }

--- a/src/commands/force/mdapi/deploy/cancel.ts
+++ b/src/commands/force/mdapi/deploy/cancel.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../formatters/deployCancelResultFormatter';
 
 Messages.importMessagesDirectory(__dirname);
-const messages = Messages.loadMessages('@salesforce/plugin-source', 'cancel');
+const messages = Messages.loadMessages('@salesforce/plugin-source', 'md.cancel');
 
 export class Cancel extends DeployCommand {
   public static readonly description = messages.getMessage('description');
@@ -30,13 +30,15 @@ export class Cancel extends DeployCommand {
       default: Duration.minutes(DeployCommand.DEFAULT_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
-      longDescription: messages.getMessage('flagsLong.wait'),
+      longDescription: messages.getMessage('flags.waitLong'),
     }),
     jobid: flags.id({
       char: 'i',
       description: messages.getMessage('flags.jobid'),
     }),
   };
+  // The most important difference between this and source:deploy:cancel
+  public isSourceStash = false;
 
   public async run(): Promise<DeployCancelCommandResult> {
     await this.cancel();

--- a/src/commands/force/mdapi/deploy/cancel.ts
+++ b/src/commands/force/mdapi/deploy/cancel.ts
@@ -7,7 +7,7 @@
 
 import * as os from 'os';
 import { flags, FlagsConfig } from '@salesforce/command';
-import { Messages } from '@salesforce/core';
+import { Messages, SfdxError } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
 import { RequestStatus } from '@salesforce/source-deploy-retrieve';
 import { DeployCommand } from '../../../../deployCommand';
@@ -34,6 +34,13 @@ export class Cancel extends DeployCommand {
     jobid: flags.id({
       char: 'i',
       description: messages.getMessage('flags.jobid'),
+      validate: (val) => {
+        if (val.startsWith('0Af')) {
+          return true;
+        } else {
+          throw SfdxError.create('@salesforce/plugin-source', 'deploy', 'invalidDeployId');
+        }
+      },
     }),
   };
   // The most important difference between this and source:deploy:cancel
@@ -47,11 +54,18 @@ export class Cancel extends DeployCommand {
 
   protected async cancel(): Promise<void> {
     const deployId = this.resolveDeployId(this.getFlag<string>('jobid'));
+    try {
+      const deploy = this.createDeploy(deployId);
+      await deploy.cancel();
 
-    const deploy = this.createDeploy(deployId);
-    await deploy.cancel();
-
-    this.deployResult = await this.poll(deployId);
+      this.deployResult = await this.poll(deployId);
+    } catch (e) {
+      if (e instanceof Error) {
+        throw SfdxError.create('@salesforce/plugin-source', 'cancel', 'CancelFailed', [e.message]);
+      } else {
+        throw SfdxError.wrap(e);
+      }
+    }
   }
 
   protected resolveSuccess(): void {

--- a/src/commands/force/source/delete.ts
+++ b/src/commands/force/source/delete.ts
@@ -44,7 +44,7 @@ export class Delete extends DeployCommand {
     }),
     wait: flags.minutes({
       char: 'w',
-      default: Duration.minutes(Delete.DEFAULT_SRC_WAIT_MINUTES),
+      default: Duration.minutes(Delete.DEFAULT_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
       longDescription: messages.getMessage('flagsLong.wait'),

--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -42,7 +42,7 @@ export class Deploy extends DeployCommand {
     }),
     wait: flags.minutes({
       char: 'w',
-      default: Duration.minutes(Deploy.DEFAULT_SRC_WAIT_MINUTES),
+      default: Duration.minutes(Deploy.DEFAULT_WAIT_MINUTES),
       min: Duration.minutes(0), // wait=0 means deploy is asynchronous
       description: messages.getMessage('flags.wait'),
       longDescription: messages.getMessage('flagsLong.wait'),

--- a/src/commands/force/source/deploy/cancel.ts
+++ b/src/commands/force/source/deploy/cancel.ts
@@ -9,7 +9,6 @@ import * as os from 'os';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
-import { getString } from '@salesforce/ts-types';
 import { RequestStatus } from '@salesforce/source-deploy-retrieve';
 import { DeployCommand } from '../../../../deployCommand';
 import {
@@ -54,7 +53,7 @@ export class Cancel extends DeployCommand {
   }
 
   protected resolveSuccess(): void {
-    const status = getString(this.deployResult, 'response.status');
+    const status = this.deployResult.response.status;
     if (status !== RequestStatus.Canceled) {
       this.setExitCode(1);
     }

--- a/src/commands/force/source/deploy/report.ts
+++ b/src/commands/force/source/deploy/report.ts
@@ -9,7 +9,6 @@ import * as os from 'os';
 import { Messages, SfdxProject } from '@salesforce/core';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Duration, env } from '@salesforce/kit';
-import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
 import { DeployCommand } from '../../../../deployCommand';
 import {
   DeployReportCommandResult,
@@ -30,7 +29,7 @@ export class Report extends DeployCommand {
   public static readonly flagsConfig: FlagsConfig = {
     wait: flags.minutes({
       char: 'w',
-      default: Duration.minutes(DeployCommand.DEFAULT_SRC_WAIT_MINUTES),
+      default: Duration.minutes(DeployCommand.DEFAULT_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
       longDescription: messages.getMessage('flagsLong.wait'),
@@ -48,15 +47,6 @@ export class Report extends DeployCommand {
     await this.doReport();
     this.resolveSuccess();
     return this.formatResult();
-  }
-
-  /**
-   * This method is here to provide a workaround to stubbing a constructor in the tests.
-   *
-   * @param id
-   */
-  public createDeploy(id?: string): MetadataApiDeploy {
-    return new MetadataApiDeploy({ usernameOrConnection: this.org.getUsername(), id });
   }
 
   protected async doReport(): Promise<void> {

--- a/src/commands/force/source/deploy/report.ts
+++ b/src/commands/force/source/deploy/report.ts
@@ -6,7 +6,7 @@
  */
 
 import * as os from 'os';
-import { Messages, SfdxProject } from '@salesforce/core';
+import { Messages, SfdxError, SfdxProject } from '@salesforce/core';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Duration, env } from '@salesforce/kit';
 import { DeployCommand } from '../../../../deployCommand';
@@ -38,6 +38,13 @@ export class Report extends DeployCommand {
       char: 'i',
       description: messages.getMessage('flags.jobid'),
       longDescription: messages.getMessage('flagsLong.jobid'),
+      validate: (val) => {
+        if (val.startsWith('0Af')) {
+          return true;
+        } else {
+          throw SfdxError.create('@salesforce/plugin-source', 'deploy', 'invalidDeployId');
+        }
+      },
     }),
     verbose: flags.builtin({
       description: messages.getMessage('flags.verbose'),

--- a/src/commands/force/source/retrieve.ts
+++ b/src/commands/force/source/retrieve.ts
@@ -10,12 +10,12 @@ import { join } from 'path';
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Messages, SfdxProject } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
-import { RetrieveResult, ComponentSet, RequestStatus } from '@salesforce/source-deploy-retrieve';
+import { ComponentSet, RequestStatus, RetrieveResult } from '@salesforce/source-deploy-retrieve';
 import { SourceCommand } from '../../../sourceCommand';
 import {
-  RetrieveResultFormatter,
-  RetrieveCommandResult,
   PackageRetrieval,
+  RetrieveCommandResult,
+  RetrieveResultFormatter,
 } from '../../../formatters/retrieveResultFormatter';
 import { ComponentSetBuilder } from '../../../componentSetBuilder';
 
@@ -41,7 +41,7 @@ export class Retrieve extends SourceCommand {
     }),
     wait: flags.minutes({
       char: 'w',
-      default: Duration.minutes(SourceCommand.DEFAULT_SRC_WAIT_MINUTES),
+      default: Duration.minutes(SourceCommand.DEFAULT_WAIT_MINUTES),
       min: Duration.minutes(1),
       description: messages.getMessage('flags.wait'),
       longDescription: messages.getMessage('flagsLong.wait'),

--- a/src/deployCommand.ts
+++ b/src/deployCommand.ts
@@ -90,7 +90,7 @@ export abstract class DeployCommand extends SourceCommand {
       } catch (err: unknown) {
         const error = err as Error & { code: string };
         if (error.name === 'JsonParseError') {
-          const stashFilePath = stash.getPath();
+          const stashFilePath = stash?.getPath();
           const corruptFilePath = `${stashFilePath}_corrupted_${Date.now()}`;
           fs.renameSync(stashFilePath, corruptFilePath);
           const invalidStashErr = SfdxError.create('@salesforce/plugin-source', 'deploy', 'InvalidStashFile', [
@@ -100,7 +100,8 @@ export abstract class DeployCommand extends SourceCommand {
           invalidStashErr.stack = `${invalidStashErr.stack}\nDue to:\n${error.stack}`;
           throw invalidStashErr;
         }
-        if (error.code === 'ENOENT') {
+        if (error.code === 'ENOENT' || !stash?.get(this.getStashKey())) {
+          // if the file doesn't exist, or the key doesn't exist in the stash
           throw SfdxError.create('@salesforce/plugin-source', 'deploy', 'MissingDeployId');
         }
         throw SfdxError.wrap(error);

--- a/src/deployCommand.ts
+++ b/src/deployCommand.ts
@@ -13,7 +13,7 @@ import {
   MetadataApiDeployStatus,
 } from '@salesforce/source-deploy-retrieve';
 import { ConfigAggregator, ConfigFile, PollingClient, SfdxError, StatusResult } from '@salesforce/core';
-import { AnyJson, asString, getBoolean } from '@salesforce/ts-types';
+import { AnyJson, getBoolean } from '@salesforce/ts-types';
 import { Duration, once } from '@salesforce/kit';
 import { SourceCommand } from './sourceCommand';
 
@@ -80,13 +80,11 @@ export abstract class DeployCommand extends SourceCommand {
       try {
         stash = this.getStash();
         stash.readSync(true);
-        const deployId = asString(
-          (
-            stash.get(this.getStashKey()) as {
-              jobid: string;
-            }
-          ).jobid
-        );
+        const deployId = (
+          stash.get(this.getStashKey()) as {
+            jobid: string;
+          }
+        ).jobid;
         this.logger.debug(`Using deploy ID: ${deployId} from ${stash.getPath()}`);
         return deployId;
       } catch (err: unknown) {

--- a/src/sourceCommand.ts
+++ b/src/sourceCommand.ts
@@ -20,7 +20,7 @@ export type ProgressBar = {
 };
 
 export abstract class SourceCommand extends SfdxCommand {
-  public static readonly DEFAULT_SRC_WAIT_MINUTES = 33;
+  public static readonly DEFAULT_WAIT_MINUTES = 33;
 
   protected xorFlags: string[] = [];
   protected progressBar?: ProgressBar;

--- a/test/commands/mdapi/cancel.test.ts
+++ b/test/commands/mdapi/cancel.test.ts
@@ -13,12 +13,12 @@ import { ConfigFile, Org, SfdxProject } from '@salesforce/core';
 import { IConfig } from '@oclif/config';
 import { UX } from '@salesforce/command';
 import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
-import { Cancel } from '../../../src/commands/force/source/deploy/cancel';
+import { Cancel } from '../../../src/commands/force/mdapi/deploy/cancel';
 import { DeployCancelResultFormatter } from '../../../src/formatters/deployCancelResultFormatter';
 import { DeployCommandResult } from '../../../src/formatters/deployResultFormatter';
-import { getDeployResult } from './deployResponses';
+import { getDeployResult } from '../source/deployResponses';
 
-describe('force:source:deploy:cancel', () => {
+describe('force:source:mdapi:cancel', () => {
   const sandbox = sinon.createSandbox();
   const username = 'cancel-test@org.com';
   const defaultDir = join('my', 'default', 'package');

--- a/test/nuts/mdapi.nut.ts
+++ b/test/nuts/mdapi.nut.ts
@@ -8,7 +8,7 @@ import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { DescribeMetadataResult } from 'jsforce';
 import { exec } from 'shelljs';
-import { getString } from '@salesforce/ts-types';
+import { DeployCancelCommandResult } from '../../src/formatters/deployCancelResultFormatter';
 
 let session: TestSession;
 
@@ -67,13 +67,13 @@ describe('mdapi NUTs', () => {
       const deploy = JSON.parse(exec('sfdx force:mdapi:deploy -d mdapi -w 0 --json', { silent: true })) as {
         result: { id: string };
       };
-      const result = execCmd('force:mdapi:deploy:cancel --json');
+      const result = execCmd<DeployCancelCommandResult>('force:mdapi:deploy:cancel --json');
       expect(result.jsonOutput.status).to.equal(0);
       const json = result.jsonOutput.result;
       expect(json).to.have.property('canceledBy');
       expect(json).to.have.property('status');
-      expect(getString(json, 'status')).to.equal('Canceled');
-      expect(getString(json, 'id')).to.equal(deploy.result.id);
+      expect(json.status).to.equal('Canceled');
+      expect(json.id).to.equal(deploy.result.id);
     });
 
     it('will cancel an mdapi deploy via the specified deploy id', () => {
@@ -82,13 +82,13 @@ describe('mdapi NUTs', () => {
       const deploy = JSON.parse(exec('sfdx force:mdapi:deploy -d mdapi -w 0 --json', { silent: true })) as {
         result: { id: string };
       };
-      const result = execCmd(`force:mdapi:deploy:cancel --json --jobid ${deploy.result.id}`);
+      const result = execCmd<DeployCancelCommandResult>(`force:mdapi:deploy:cancel --json --jobid ${deploy.result.id}`);
       expect(result.jsonOutput.status).to.equal(0);
       const json = result.jsonOutput.result;
       expect(json).to.have.property('canceledBy');
       expect(json).to.have.property('status');
-      expect(getString(json, 'status')).to.equal('Canceled');
-      expect(getString(json, 'id')).to.equal(deploy.result.id);
+      expect(json.status).to.equal('Canceled');
+      expect(json.id).to.equal(deploy.result.id);
     });
   });
 

--- a/test/nuts/mdapi.nut.ts
+++ b/test/nuts/mdapi.nut.ts
@@ -5,8 +5,10 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { expect } from 'chai';
-import { TestSession, execCmd } from '@salesforce/cli-plugins-testkit';
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { DescribeMetadataResult } from 'jsforce';
+import { exec } from 'shelljs';
+import { getString } from '@salesforce/ts-types';
 
 let session: TestSession;
 
@@ -55,6 +57,38 @@ describe('mdapi NUTs', () => {
         suffix: 'labels',
         xmlName: 'CustomLabels',
       });
+    });
+  });
+
+  describe('mdapi:deploy:cancel', () => {
+    it('will cancel an mdapi deploy via the stash.json', () => {
+      execCmd('force:source:convert --outputdir mdapi');
+      // TODO: once mdapi:deploy is migrated switch to execCmd
+      const deploy = JSON.parse(exec('sfdx force:mdapi:deploy -d mdapi -w 0 --json', { silent: true })) as {
+        result: { id: string };
+      };
+      const result = execCmd('force:mdapi:deploy:cancel --json');
+      expect(result.jsonOutput.status).to.equal(0);
+      const json = result.jsonOutput.result;
+      expect(json).to.have.property('canceledBy');
+      expect(json).to.have.property('status');
+      expect(getString(json, 'status')).to.equal('Canceled');
+      expect(getString(json, 'id')).to.equal(deploy.result.id);
+    });
+
+    it('will cancel an mdapi deploy via the specified deploy id', () => {
+      execCmd('force:source:convert --outputdir mdapi');
+      // TODO: once mdapi:deploy is migrated switch to execCmd
+      const deploy = JSON.parse(exec('sfdx force:mdapi:deploy -d mdapi -w 0 --json', { silent: true })) as {
+        result: { id: string };
+      };
+      const result = execCmd(`force:mdapi:deploy:cancel --json --jobid ${deploy.result.id}`);
+      expect(result.jsonOutput.status).to.equal(0);
+      const json = result.jsonOutput.result;
+      expect(json).to.have.property('canceledBy');
+      expect(json).to.have.property('status');
+      expect(getString(json, 'status')).to.equal('Canceled');
+      expect(getString(json, 'id')).to.equal(deploy.result.id);
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
moves `mdapi:deploy:cancel` command and messages
extends `plugin-source` base classes correctly
updates base classes to support `MDAPI_DEPLOY` stash key
adds UTs
adds NUTs

`source:deploy:cancel`,`source:deploy:report`, `mdapi:deploy:cancel` all validate the passed in deploy ID parameter
fixes issue when stash is missing a requested key/value

### What issues does this PR fix or reference?
@W-9603715@