### PR TITLE
fix: conditionally include folder

### DIFF
--- a/src/commands/force/mdapi/listmetadata.ts
+++ b/src/commands/force/mdapi/listmetadata.ts
@@ -68,7 +68,10 @@ export class ListMetadata extends SourceCommand {
 
     this.validateResultFile();
 
-    const query: ListMetadataQuery = { type, folder };
+    const query: ListMetadataQuery = { type };
+    if (folder) {
+      query.folder = folder;
+    }
     const connection = this.org.getConnection();
     const result = (await connection.metadata.list(query, apiversion)) || [];
     this.listResult = Array.isArray(result) ? result : [result];

--- a/test/nuts/mdapi.nut.ts
+++ b/test/nuts/mdapi.nut.ts
@@ -49,11 +49,21 @@ describe('mdapi NUTs', () => {
   });
 
   describe('mdapi:listmetadata', () => {
-    it('should successfully execute listmetadata', () => {
+    it('should successfully execute listmetadata for type CustomObject', () => {
       const result = execCmd('force:mdapi:listmetadata --json --metadatatype CustomObject');
       expect(result.jsonOutput.status).to.equal(0);
       expect(result.jsonOutput.result).to.be.an('array').with.length.greaterThan(100);
       expect(result.jsonOutput.result[0]).to.have.property('type', 'CustomObject');
+    });
+
+    it('should successfully execute listmetadata for type ListView', () => {
+      // ListView is sensitive to how the connection.metadata.list() call is made.
+      // e.g., if you pass { type: 'ListView', folder: undefined } it will not return
+      // any ListViews but if you pass { type: 'ListView' } it returns all ListViews.
+      const result = execCmd('force:mdapi:listmetadata --json --metadatatype ListView');
+      expect(result.jsonOutput.status).to.equal(0);
+      expect(result.jsonOutput.result).to.be.an('array').with.length.greaterThan(10);
+      expect(result.jsonOutput.result[0]).to.have.property('type', 'ListView');
     });
   });
 


### PR DESCRIPTION
### What does this PR do?
only include the folder ListMetadataQuery for jsForce's connection.metadata.list when it's a folder type.  Even an undefined folder value causes problems for the ListView type.

### What issues does this PR fix or reference?
@W-10203090@
