### PR TITLE
Sm/mpd-push

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,7 @@
 {
   "require": "ts-node/register,source-map-support/register",
   "watch-extensions": "ts",
+  "watch-files": ["src", "test"],
   "recursive": true,
   "reporter": "spec",
   "timeout": 5000

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "prepare": "sf-install",
     "pretest": "sf-compile-test",
     "test": "sf-test",
+    "test:watch": "mocha --watch \"./test/**/*.test.ts\"",
     "test:command-reference": "./bin/run commandreference:generate --erroronwarnings",
     "test:deprecation-policy": "./bin/run snapshot:compare",
     "test:nuts": "cross-env PLUGIN_SOURCE_SEED_EXCLUDE=deploy.async ts-node ./test/nuts/generateNuts.ts && nyc mocha \"**/*.nut.ts\"  --slow 4500 --timeout 600000 --parallel --retries 0",

--- a/src/commands/force/source/beta/push.ts
+++ b/src/commands/force/source/beta/push.ts
@@ -176,7 +176,7 @@ export default class Push extends DeployCommand {
     };
     // all successes
     if (this.deployResults.every((result) => isSuccessLike(result))) {
-      this.setExitCode(StatusCodeMap.get(this.deployResults[0].response.status));
+      return this.setExitCode(0);
     }
 
     // 1 and 0 === 68 "partial success"
@@ -184,9 +184,10 @@ export default class Push extends DeployCommand {
       this.deployResults.some((result) => isSuccessLike(result)) &&
       this.deployResults.some((result) => StatusCodeMap.get(result.response.status) === 1)
     ) {
-      this.setExitCode(68);
+      return this.setExitCode(68);
     }
-    this.setExitCode(0);
+    this.logger.warn('Unexpected exit code', this.deployResults);
+    this.setExitCode(1);
   }
 
   protected formatResult(): PushResponse[] {

--- a/test/formatters/pushResultFormater.test.ts
+++ b/test/formatters/pushResultFormater.test.ts
@@ -14,22 +14,26 @@ import { PushResultFormatter } from '../../src/formatters/pushResultFormatter';
 
 describe('PushResultFormatter', () => {
   const logger = Logger.childFromRoot('deployTestLogger').useMemoryLogging();
-  const deployResultSuccess = getDeployResult('successSync');
-  const deployResultFailure = getDeployResult('failed');
+  const deployResultSuccess = [getDeployResult('successSync')];
+  const deployResultFailure = [getDeployResult('failed')];
 
   const sandbox = sinon.createSandbox();
 
   let uxMock;
   let tableStub: sinon.SinonStub;
+  let headerStub: sinon.SinonStub;
   beforeEach(() => {
     tableStub = sandbox.stub();
+    headerStub = sandbox.stub();
     uxMock = stubInterface<UX>(sandbox, {
       table: tableStub,
+      styledHeader: headerStub,
     });
   });
 
   afterEach(() => {
     sandbox.restore();
+    process.exitCode = undefined;
   });
 
   describe('json', () => {
@@ -59,20 +63,30 @@ describe('PushResultFormatter', () => {
 
   describe('human output', () => {
     it('returns expected output for success', () => {
+      process.exitCode = 0;
       const formatter = new PushResultFormatter(logger, uxMock as UX, {}, deployResultSuccess);
       formatter.display();
-      expect(tableStub.callCount).to.equal(1);
+      expect(headerStub.callCount, JSON.stringify(headerStub.args)).to.equal(1);
+      expect(tableStub.callCount, JSON.stringify(tableStub.args)).to.equal(1);
     });
     describe('quiet', () => {
       it('does not display successes for quiet', () => {
+        process.exitCode = 0;
         const formatter = new PushResultFormatter(logger, uxMock as UX, { quiet: true }, deployResultSuccess);
         formatter.display();
+        expect(headerStub.callCount, JSON.stringify(headerStub.args)).to.equal(0);
+        expect(formatter.getJson()).to.deep.equal([]);
         expect(tableStub.callCount).to.equal(0);
       });
-      it('displays errors for quiet', () => {
+      it('displays errors and throws for quiet', () => {
+        process.exitCode = 1;
         const formatter = new PushResultFormatter(logger, uxMock as UX, { quiet: true }, deployResultFailure);
-        formatter.display();
-        expect(tableStub.callCount).to.equal(1);
+        try {
+          formatter.display();
+          throw new Error('should have thrown');
+        } catch (err) {
+          expect(tableStub.callCount).to.equal(1);
+        }
       });
     });
   });

--- a/test/nuts/trackingCommands/mpd-sequential.nut.ts
+++ b/test/nuts/trackingCommands/mpd-sequential.nut.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-disable no-console */
+
+import * as path from 'path';
+import { fs, AuthInfo, Connection } from '@salesforce/core';
+import { expect } from 'chai';
+import { TestSession, execCmd } from '@salesforce/cli-plugins-testkit';
+import { replaceRenamedCommands } from '@salesforce/source-tracking';
+import { PushResponse } from '../../../src/formatters/pushResultFormatter';
+
+let session: TestSession;
+let conn: Connection;
+
+describe('end-to-end-test for tracking with an org (single packageDir)', () => {
+  before(async () => {
+    session = await TestSession.create({
+      project: {
+        gitClone: 'https://github.com/salesforcecli/sample-project-multiple-packages',
+      },
+      setupCommands: [`sfdx force:org:create -d 1 -s -f ${path.join('config', 'project-scratch-def.json')}`],
+    });
+
+    // set `pushPackageDirectoriesSequentially`
+    const originalProject = (await fs.readJson(path.join(session.project.dir, 'sfdx-project.json'))) as Record<
+      string,
+      unknown
+    >;
+    await fs.writeJson(path.join(session.project.dir, 'sfdx-project.json'), {
+      ...originalProject,
+      pushPackageDirectoriesSequentially: true,
+    });
+
+    conn = await Connection.create({
+      authInfo: await AuthInfo.create({
+        username: (session.setup[0] as { result: { username: string } }).result?.username,
+      }),
+    });
+  });
+
+  after(async () => {
+    await session?.zip(undefined, 'artifacts');
+    await session?.clean();
+  });
+
+  describe('mpd sequential', () => {
+    it('pushes using MPD', () => {
+      const result = execCmd<PushResponse[]>(replaceRenamedCommands('force:source:push --json'), {
+        ensureExitCode: 0,
+      }).jsonOutput.result;
+      expect(result).to.be.an.instanceof(Array);
+      // the fields should be populated
+      expect(result.every((row) => row.type && row.fullName)).to.equal(true);
+    });
+
+    it('should have 4 deployments', async () => {
+      const deployments = await conn.tooling.query('SELECT Id, Status, StartDate, CompletedDate FROM DeployRequest');
+      // one deployment was the scratch org settings; the other 3 are the 3 pkgDirs
+      expect(deployments.totalSize).to.equal(4);
+    });
+  });
+});

--- a/test/nuts/trackingCommands/resetClear.nut.ts
+++ b/test/nuts/trackingCommands/resetClear.nut.ts
@@ -127,7 +127,7 @@ describe('reset and clear', () => {
       expect(lowestRevision).lessThan(revisionFile.serverMaxRevisionCounter as number);
       // revisions are not retrieved
       revisions.map((revision) => {
-        expect(revision.serverRevisionCounter !== revision.lastRetrievedFromServer).to.equal(true);
+        expect(revision.serverRevisionCounter).to.not.equal(revision.lastRetrievedFromServer);
         expect(revision.lastRetrievedFromServer).to.equal(null);
       });
     });
@@ -138,11 +138,9 @@ describe('reset and clear', () => {
       const revisions = await getRevisionsAsArray();
 
       revisions.map((revision) => {
-        if (revision.serverRevisionCounter === lowestRevision) {
-          expect(revision.serverRevisionCounter === revision.lastRetrievedFromServer).to.equal(true);
-        } else {
-          expect(revision.serverRevisionCounter !== revision.lastRetrievedFromServer).to.equal(true);
-        }
+        revision.serverRevisionCounter === lowestRevision
+          ? expect(revision.serverRevisionCounter).to.equal(revision.lastRetrievedFromServer)
+          : expect(revision.serverRevisionCounter).to.not.equal(revision.lastRetrievedFromServer);
       });
     });
 


### PR DESCRIPTION
### What does this PR do?
[draft until https://github.com/forcedotcom/source-tracking/pull/53 merges]

new option in sfdx-project.json for `pushPackageDirectoriesSequentially`
use new STL logic for byPkgDir
iterate array of  componentSets for push
NUT for asserting how many deploys happened from the org

### What issues does this PR fix or reference?
@W-10146239@

QA notes:

top-level boolean prop `pushPackageDirectoriesSequentially` on sfdx-project.json

use this updated push command to QA the STL changes
I used https://github.com/salesforcecli/sample-project-multiple-packages as a test repo

check what happens with duplicate files in json output from subsequent deployments--do you get duplicates?  Is that different from toolbelt or the same?

testing ideas that I didn't try
examining hook output (should fire once for each directory)
check source tracking files (`source:status`) on an mpd deployment
check `pushPackageDirectoriesSequentially` when there's only one pkgDirectory
test the human (non-json) output with a MPD project...the messages and fileResponses should all merge into one table across all the deploys
have a failure on any one pkgDir...it *should* stop any other deployments from happening.