### PR TITLE
chore: enable deploy async NUTs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,14 +70,7 @@ workflows:
                 - linux
                 - windows
               command:
-                - 'yarn test:nuts:convert'
-                - 'yarn test:nuts:delete'
-                - 'yarn test:nuts:deploy'
-                - 'yarn test:nuts:manifest:create'
-                - 'yarn test:nuts:retrieve'
-                - 'yarn test:nuts:specialTypes'
-                - 'yarn test:nuts:deploy:destructive'
-                - 'yarn test:nuts:tracking'
+                - 'yarn test:nuts:deploy:async'
       - release-management/release-package:
           sign: true
           github-release: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,15 @@ workflows:
                 - linux
                 - windows
               command:
+                - 'yarn test:nuts:convert'
+                - 'yarn test:nuts:delete'
+                - 'yarn test:nuts:deploy'
                 - 'yarn test:nuts:deploy:async'
+                - 'yarn test:nuts:manifest:create'
+                - 'yarn test:nuts:retrieve'
+                - 'yarn test:nuts:specialTypes'
+                - 'yarn test:nuts:deploy:destructive'
+                - 'yarn test:nuts:tracking'
       - release-management/release-package:
           sign: true
           github-release: true

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "test": "sf-test",
     "test:command-reference": "./bin/run commandreference:generate --erroronwarnings",
     "test:deprecation-policy": "./bin/run snapshot:compare",
-    "test:nuts": "cross-env PLUGIN_SOURCE_SEED_EXCLUDE=deploy.async ts-node ./test/nuts/generateNuts.ts && nyc mocha \"**/*.nut.ts\"  --slow 4500 --timeout 600000 --parallel --retries 0",
+    "test:nuts": "ts-node ./test/nuts/generateNuts.ts && nyc mocha \"**/*.nut.ts\"  --slow 4500 --timeout 600000 --parallel --retries 0",
     "test:nuts:convert": "cross-env PLUGIN_SOURCE_SEED_FILTER=convert ts-node ./test/nuts/generateNuts.ts && mocha \"test/nuts/generated/*.nut.ts\" --slow 4500 --timeout 600000 --parallel --retries 0",
     "test:nuts:delete": "mocha \"test/nuts/delete.nut.ts\" --slow 4500 --timeout 600000 --parallel --retries 0",
     "test:nuts:deploy": "cross-env PLUGIN_SOURCE_SEED_FILTER=deploy PLUGIN_SOURCE_SEED_EXCLUDE=async ts-node ./test/nuts/generateNuts.ts && mocha \"test/nuts/generated/*.nut.ts\" --slow 4500 --timeout 600000 --parallel --retries 0",


### PR DESCRIPTION
### What does this PR do?
Enables deploy async NUTs.
There were disabled a few months ago because of a memory leak, today I was able to run them locally (`test:nuts:deploy:async`) on my mac and also passed on linux/win ✅
Pretty sure the bug causing the mem leak was addressed in some SDR version 😄 

### What issues does this PR fix or reference?
@W-9800765@
