### PR TITLE
feat: add deploy filter for sourcepaths

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -72,6 +72,7 @@
     "flags": [
       "apiversion",
       "checkonly",
+      "filter",
       "ignoreerrors",
       "ignorewarnings",
       "json",

--- a/messages/deploy.json
+++ b/messages/deploy.json
@@ -17,6 +17,7 @@
   ],
   "flags": {
     "sourcePath": "comma-separated list of source file paths to deploy",
+    "filter": "file path for manifest (package.xml) of components to filter components in source file paths",
     "manifest": "file path for manifest (package.xml) of components to deploy",
     "metadata": "comma-separated list of metadata component names",
     "wait": "wait time for command to finish in minutes",
@@ -35,6 +36,10 @@
     "sourcePath": [
       "A comma-separated list of paths to the local source files to deploy. The supplied paths can be to a single file (in which case the operation is applied to only one file) or to a folder (in which case the operation is applied to all metadata types in the directory and its sub-directories).",
       "If you specify this parameter, don’t specify --manifest or --metadata."
+    ],
+    "filter": [
+      "The complete path for the manifest (package.xml) file that specifies the components to include. Only the specified child components are included.",
+      "If you specify this parameter, specify --sourcepath."
     ],
     "manifest": [
       "The complete path for the manifest (package.xml) file that specifies the components to deploy. All child components are included.",

--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -100,6 +100,11 @@ export class Deploy extends DeployCommand {
       longDescription: messages.getMessage('flagsLong.sourcePath'),
       exclusive: ['manifest', 'metadata'],
     }),
+    filter: flags.filepath({
+      description: messages.getMessage('flags.filter'),
+      longDescription: messages.getMessage('flagsLong.filter'),
+      dependsOn: ['sourcepath'],
+    }),
     manifest: flags.filepath({
       char: 'x',
       description: messages.getMessage('flags.manifest'),
@@ -152,6 +157,7 @@ export class Deploy extends DeployCommand {
         apiversion: this.getFlag<string>('apiversion'),
         sourceapiversion: await this.getSourceApiVersion(),
         sourcepath: this.getFlag<string[]>('sourcepath'),
+        filterpath: this.getFlag<string>('filter'),
         manifest: this.flags.manifest && {
           manifestPath: this.getFlag<string>('manifest'),
           directoryPaths: this.getPackageDirs(),

--- a/src/componentSetBuilder.ts
+++ b/src/componentSetBuilder.ts
@@ -23,7 +23,7 @@ export type ComponentSetOptions = {
   packagenames?: string[];
   sourcepath?: string[];
   manifest?: ManifestOption;
-
+  filterpath?: string;
   metadata?: MetadataOption;
   apiversion?: string;
   sourceapiversion?: string;
@@ -42,7 +42,7 @@ export class ComponentSetBuilder {
     const logger = Logger.childFromRoot('createComponentSet');
     let componentSet: ComponentSet;
 
-    const { sourcepath, manifest, metadata, packagenames, apiversion, sourceapiversion } = options;
+    const { sourcepath, manifest, metadata, packagenames, apiversion, sourceapiversion, filterpath } = options;
     try {
       if (sourcepath) {
         logger.debug(`Building ComponentSet from sourcepath: ${sourcepath.toString()}`);
@@ -53,7 +53,16 @@ export class ComponentSetBuilder {
           }
           fsPaths.push(path.resolve(filepath));
         });
-        componentSet = ComponentSet.fromSource({ fsPaths });
+        let include: ComponentSet;
+
+        if (filterpath) {
+          include = await ComponentSet.fromManifest({
+            manifestPath: filterpath,
+            resolveSourcePaths: fsPaths,
+          });
+        }
+
+        componentSet = ComponentSet.fromSource({ fsPaths, include });
       }
 
       // Return empty ComponentSet and use packageNames in the library via `.retrieve` options

--- a/test/commands/source/componentSetBuilder.test.ts
+++ b/test/commands/source/componentSetBuilder.test.ts
@@ -58,7 +58,7 @@ describe('ComponentSetBuilder', () => {
         metadata: undefined,
       });
 
-      const expectedArg = { fsPaths: [path.resolve(sourcepath[0])] };
+      const expectedArg = { fsPaths: [path.resolve(sourcepath[0])], include: undefined };
       expect(fromSourceStub.calledOnceWith(expectedArg)).to.equal(true);
       expect(compSet.size).to.equal(1);
       expect(compSet.has(apexClassComponent)).to.equal(true);
@@ -78,7 +78,7 @@ describe('ComponentSetBuilder', () => {
       });
       const expectedPath1 = path.resolve(sourcepath[0]);
       const expectedPath2 = path.resolve(sourcepath[1]);
-      const expectedArg = { fsPaths: [expectedPath1, expectedPath2] };
+      const expectedArg = { fsPaths: [expectedPath1, expectedPath2], include: undefined };
       expect(fromSourceStub.calledOnceWith(expectedArg)).to.equal(true);
       expect(compSet.size).to.equal(2);
       expect(compSet.has(apexClassComponent)).to.equal(true);
@@ -97,7 +97,7 @@ describe('ComponentSetBuilder', () => {
       };
 
       const compSet = await ComponentSetBuilder.build(options);
-      const expectedArg = { fsPaths: [path.resolve(sourcepath[0])] };
+      const expectedArg = { fsPaths: [path.resolve(sourcepath[0])], include: undefined };
       expect(fromSourceStub.calledOnceWith(expectedArg)).to.equal(true);
       expect(compSet.size).to.equal(0);
       expect(compSet.apiVersion).to.equal(options.apiversion);
@@ -115,7 +115,7 @@ describe('ComponentSetBuilder', () => {
       };
 
       const compSet = await ComponentSetBuilder.build(options);
-      const expectedArg = { fsPaths: [path.resolve(sourcepath[0])] };
+      const expectedArg = { fsPaths: [path.resolve(sourcepath[0])], include: undefined };
       expect(fromSourceStub.calledOnceWith(expectedArg)).to.equal(true);
       expect(compSet.size).to.equal(0);
       expect(compSet.sourceApiVersion).to.equal(options.sourceapiversion);

--- a/test/commands/source/deploy.test.ts
+++ b/test/commands/source/deploy.test.ts
@@ -139,6 +139,7 @@ describe('force:source:deploy', () => {
       manifest: undefined,
       metadata: undefined,
       apiversion: undefined,
+      filterpath: undefined,
       sourceapiversion: undefined,
     };
     const expectedArgs = { ...defaultArgs, ...overrides };


### PR DESCRIPTION
### What does this PR do?

Adds a `filter` parameter for `source:deploy` which can be used together with `sourcepaths` 

### What issues does this PR fix or reference?

Before `source-deploy-retrieve` the `source:deploy` command was able to deploy each `packageDir` one by one in the order specified in the `sfdx-project.json`, if you used `manifest` as a parameter.

This was a way to deploy only selected components from each `packageDir` with a manifest file, which contains all selected components from all folders.

As this behaviour is not possible with `source-deploy-retrieve` anymore, a parameter `filter` togehter with `sourcepaths` can bring back this "old" behaviour. Iteration of the folders needs to be done manually.