### PR TITLE
Revert "chore: sync .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ package-lock.json
 # debug logs
 npm-error.log
 yarn-error.log
-
+lerna-debug.log
 
 # compile source
 lib
@@ -39,3 +39,6 @@ node_modules
 # os specific files
 .DS_Store
 .idea
+
+# ignore generated nut tests
+test/nuts/generated/


### PR DESCRIPTION
Reverts salesforcecli/plugin-source#352

```
# ignore generated nut tests
test/nuts/generated/
```
is still needed for plugin-source