### PR TITLE
fix: throw valid error when missing required params

### DIFF
--- a/messages/deploy.json
+++ b/messages/deploy.json
@@ -73,6 +73,7 @@
       "    - If specific tests are run with the RunSpecifiedTests test level, each class and trigger that was deployed is covered by at least 75% individually."
     ]
   },
+  "MissingRequiredParam": "Missing one of the following parameters: %s",
   "checkOnlySuccess": "Successfully validated the deployment. %s components deployed and %s tests run.\nUse the --verbose parameter to see detailed output.",
   "MissingDeployId": "No deploy ID was provided or found in deploy history.",
   "deployCanceled": "The deployment has been canceled by %s.",

--- a/src/commands/force/source/manifest/create.ts
+++ b/src/commands/force/source/manifest/create.ts
@@ -27,7 +27,6 @@ interface CreateCommandResult {
   path: string;
 }
 
-const xorFlags = ['metadata', 'sourcepath'];
 export class create extends SourceCommand {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
@@ -37,12 +36,12 @@ export class create extends SourceCommand {
     metadata: flags.array({
       char: 'm',
       description: messages.getMessage('flags.metadata'),
-      exactlyOne: xorFlags,
+      exclusive: ['sourcepath'],
     }),
     sourcepath: flags.array({
       char: 'p',
       description: messages.getMessage('flags.sourcepath'),
-      exactlyOne: xorFlags,
+      exclusive: ['metadata'],
     }),
     manifestname: flags.string({
       char: 'n',
@@ -59,6 +58,7 @@ export class create extends SourceCommand {
       description: messages.getMessage('flags.outputdir'),
     }),
   };
+  protected xorFlags = ['metadata', 'sourcepath'];
   private manifestName: string;
   private outputDir: string;
   private outputPath: string;
@@ -70,6 +70,7 @@ export class create extends SourceCommand {
   }
 
   protected async createManifest(): Promise<void> {
+    this.validateFlags();
     // convert the manifesttype into one of the "official" manifest names
     // if no manifesttype flag passed, use the manifestname flag
     // if no manifestname flag, default to 'package.xml'


### PR DESCRIPTION
### What does this PR do?
This PR brings back the `validateFlags` logic to `source:deploy` and `source:manifest:create` commands.
There's a current bug in oclif that makes sfdx print an invalid error message when using the `exactlyOne` prop in flags:

```bash
sfdx force:source:deploy
ERROR running force:source:deploy:  Exactly one of the following must be provided: m,a,n,i,f,e,s,t

sfdx force:source:manifest:create
ERROR running force:source:manifest:create:  Exactly one of the following must be provided: m,e,t,a,d
```

I've openen a [PR in oclif/core](https://github.com/oclif/core/pull/349) but until it's merged/we migrate to core, this should work.

### What issues does this PR fix or reference?
@W-0@
