### PR TITLE
fix: make retrieve param consistent and fix tests

### DIFF
--- a/src/commands/force/mdapi/beta/retrieve.ts
+++ b/src/commands/force/mdapi/beta/retrieve.ts
@@ -69,7 +69,7 @@ export class Retrieve extends SourceCommand {
       longDescription: messages.getMessage('flagsLong.singlepackage'),
     }),
     zipfilename: flags.string({
-      char: 'f',
+      char: 'n',
       description: messages.getMessage('flags.zipfilename'),
       longDescription: messages.getMessage('flagsLong.zipfilename'),
     }),

--- a/test/commands/mdapi/retrieve.test.ts
+++ b/test/commands/mdapi/retrieve.test.ts
@@ -244,7 +244,7 @@ describe('force:mdapi:beta:retrieve', () => {
     const result = await runRetrieveCmd([
       '--retrievetargetdir',
       retrievetargetdir,
-      '-f',
+      '-n',
       zipfilename,
       '--unzip',
       '--json',

--- a/test/nuts/seeds/deploy.async.seed.ts
+++ b/test/nuts/seeds/deploy.async.seed.ts
@@ -76,13 +76,12 @@ context('Async Deploy NUTs [name: %REPO_NAME%] [exec: %EXECUTABLE%]', () => {
         const deploy = (await testkit.deploy({
           args: `--sourcepath ${testkit.packageNames.join(',')} --wait 0`,
         })) as Result<{ id: string; result: { id: string } }>;
-        await testkit.deployCancel({ args: `-i ${deploy.result.id}` });
-
         testkit.expect.toHaveProperty(deploy.result, 'id');
 
         const cancel = execCmd<DeployCancelCommandResult>(
           `force:source:deploy:cancel -i ${deploy.result.id} --json`
         ).jsonOutput;
+
         if (cancel.status === 0) {
           // successful cancel
           expect(cancel.result.status).to.equal('Canceled');

--- a/test/nuts/seeds/retrieve.manifest.seed.ts
+++ b/test/nuts/seeds/retrieve.manifest.seed.ts
@@ -38,12 +38,14 @@ context('Retrieve manifest NUTs [name: %REPO_NAME%] [exec: %EXECUTABLE%]', () =>
   });
 
   describe('--manifest flag', () => {
+    let i = 0;
     for (const testCase of REPO.retrieve.manifest) {
       const toRetrieve = path.normalize(testCase.toRetrieve);
+      const convertDir = `convert_${i++}`;
       it(`should retrieve ${toRetrieve}`, async () => {
         // generate package.xml to use with the --manifest param
-        await testkit.convert({ args: `--sourcepath ${testCase.toRetrieve} --outputdir out` });
-        const packageXml = path.join('out', 'package.xml');
+        await testkit.convert({ args: `--sourcepath ${testCase.toRetrieve} --outputdir ${convertDir}` });
+        const packageXml = path.join(convertDir, 'package.xml');
 
         await testkit.modifyLocalGlobs(testCase.toVerify);
         await testkit.retrieve({ args: `--manifest ${packageXml}` });


### PR DESCRIPTION
### What does this PR do?
Makes the `zipfilename` parameter short char consistent between `mdapi:retrieve` and `mdapi:retrieve:report`
Fixes a few tests
### What issues does this PR fix or reference?
@W-0@