### PR TITLE
feat: GA new tracking commands

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -196,13 +196,13 @@
     "command": "force:source:pull",
     "plugin": "@salesforce/plugin-source",
     "flags": ["apiversion", "forceoverwrite", "json", "loglevel", "targetusername", "wait"],
-    "alias": []
+    "alias": ["force:source:beta:pull"]
   },
   {
     "command": "force:source:push",
     "plugin": "@salesforce/plugin-source",
     "flags": ["apiversion", "forceoverwrite", "ignorewarnings", "json", "loglevel", "quiet", "targetusername", "wait"],
-    "alias": []
+    "alias": ["force:source:beta:push"]
   },
   {
     "command": "force:source:retrieve",
@@ -227,18 +227,18 @@
     "command": "force:source:status",
     "plugin": "@salesforce/plugin-source",
     "flags": ["apiversion", "concise", "json", "local", "loglevel", "remote", "targetusername"],
-    "alias": []
+    "alias": ["force:source:beta:status"]
   },
   {
     "command": "force:source:tracking:clear",
     "plugin": "@salesforce/plugin-source",
     "flags": ["apiversion", "json", "loglevel", "noprompt", "targetusername"],
-    "alias": []
+    "alias": ["force:source:beta:tracking:clear"]
   },
   {
     "command": "force:source:tracking:reset",
     "plugin": "@salesforce/plugin-source",
     "flags": ["apiversion", "json", "loglevel", "noprompt", "revision", "targetusername"],
-    "alias": []
+    "alias": ["force:source:beta:tracking:reset"]
   }
 ]

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -98,36 +98,6 @@
     "alias": []
   },
   {
-    "command": "force:source:beta:pull",
-    "plugin": "@salesforce/plugin-source",
-    "flags": ["apiversion", "forceoverwrite", "json", "loglevel", "targetusername", "wait"],
-    "alias": []
-  },
-  {
-    "command": "force:source:beta:push",
-    "plugin": "@salesforce/plugin-source",
-    "flags": ["apiversion", "forceoverwrite", "ignorewarnings", "json", "loglevel", "quiet", "targetusername", "wait"],
-    "alias": []
-  },
-  {
-    "command": "force:source:beta:status",
-    "plugin": "@salesforce/plugin-source",
-    "flags": ["apiversion", "concise", "json", "local", "loglevel", "remote", "targetusername"],
-    "alias": []
-  },
-  {
-    "command": "force:source:beta:tracking:clear",
-    "plugin": "@salesforce/plugin-source",
-    "flags": ["apiversion", "json", "loglevel", "noprompt", "targetusername"],
-    "alias": []
-  },
-  {
-    "command": "force:source:beta:tracking:reset",
-    "plugin": "@salesforce/plugin-source",
-    "flags": ["apiversion", "json", "loglevel", "noprompt", "revision", "targetusername"],
-    "alias": []
-  },
-  {
     "command": "force:source:convert",
     "plugin": "@salesforce/plugin-source",
     "flags": ["json", "loglevel", "manifest", "metadata", "outputdir", "packagename", "rootdir", "sourcepath"],
@@ -223,6 +193,18 @@
     "alias": []
   },
   {
+    "command": "force:source:pull",
+    "plugin": "@salesforce/plugin-source",
+    "flags": ["apiversion", "forceoverwrite", "json", "loglevel", "targetusername", "wait"],
+    "alias": []
+  },
+  {
+    "command": "force:source:push",
+    "plugin": "@salesforce/plugin-source",
+    "flags": ["apiversion", "forceoverwrite", "ignorewarnings", "json", "loglevel", "quiet", "targetusername", "wait"],
+    "alias": []
+  },
+  {
     "command": "force:source:retrieve",
     "plugin": "@salesforce/plugin-source",
     "flags": [
@@ -239,6 +221,24 @@
       "verbose",
       "wait"
     ],
+    "alias": []
+  },
+  {
+    "command": "force:source:status",
+    "plugin": "@salesforce/plugin-source",
+    "flags": ["apiversion", "concise", "json", "local", "loglevel", "remote", "targetusername"],
+    "alias": []
+  },
+  {
+    "command": "force:source:tracking:clear",
+    "plugin": "@salesforce/plugin-source",
+    "flags": ["apiversion", "json", "loglevel", "noprompt", "targetusername"],
+    "alias": []
+  },
+  {
+    "command": "force:source:tracking:reset",
+    "plugin": "@salesforce/plugin-source",
+    "flags": ["apiversion", "json", "loglevel", "noprompt", "revision", "targetusername"],
     "alias": []
   }
 ]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/index.js",
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
-    "@oclif/config": "^1.18.2",
+    "@oclif/config": "^1.18.3",
     "@oclif/plugin-help": "^3.3.1",
     "@salesforce/command": "^4.2.2",
     "@salesforce/core": "^2.35.0",

--- a/package.json
+++ b/package.json
@@ -114,13 +114,8 @@
               "manifest": {
                 "description": "create a manifest to use in a deploy/retrieve"
               },
-              "beta": {
-                "description": "new versions of source tracking commands",
-                "subtopics": {
-                  "tracking": {
-                    "description": "new versions of source tracking commands"
-                  }
-                }
+              "tracking": {
+                "description": "reset and clear source tracking"
               }
             }
           },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@salesforce/command": "^4.2.2",
     "@salesforce/core": "^2.35.0",
     "@salesforce/source-deploy-retrieve": "^5.12.2",
-    "@salesforce/source-tracking": "^1.1.3",
+    "@salesforce/source-tracking": "^1.2.0",
     "chalk": "^4.1.2",
     "cli-ux": "^5.6.3",
     "got": "^11.8.3",

--- a/src/commands/force/source/pull.ts
+++ b/src/commands/force/source/pull.ts
@@ -24,6 +24,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages: Messages = Messages.loadMessages('@salesforce/plugin-source', 'pull');
 
 export default class Pull extends SourceCommand {
+  public static aliases = ['force:source:beta:pull'];
   public static description = messages.getMessage('description');
   public static help = messages.getMessage('help');
   protected static readonly flagsConfig: FlagsConfig = {

--- a/src/commands/force/source/pull.ts
+++ b/src/commands/force/source/pull.ts
@@ -15,10 +15,10 @@ import {
   RetrieveResult,
   SourceComponent,
 } from '@salesforce/source-deploy-retrieve';
-import { ChangeResult, replaceRenamedCommands, SourceTracking } from '@salesforce/source-tracking';
-import { SourceCommand } from '../../../../sourceCommand';
-import { PullResponse, PullResultFormatter } from '../../../../formatters/source/pullFormatter';
-import { trackingSetup, updateTracking } from '../../../../trackingFunctions';
+import { ChangeResult, SourceTracking } from '@salesforce/source-tracking';
+import { SourceCommand } from '../../../sourceCommand';
+import { PullResponse, PullResultFormatter } from '../../../formatters/source/pullFormatter';
+import { trackingSetup, updateTracking } from '../../../trackingFunctions';
 
 Messages.importMessagesDirectory(__dirname);
 const messages: Messages = Messages.loadMessages('@salesforce/plugin-source', 'pull');
@@ -65,7 +65,7 @@ export default class Pull extends SourceCommand {
   protected async preChecks(): Promise<void> {
     this.ux.startSpinner('Loading source tracking information');
     this.tracking = await trackingSetup({
-      commandName: replaceRenamedCommands('force:source:pull'),
+      commandName: 'force:source:pull',
       ignoreConflicts: this.getFlag<boolean>('forceoverwrite', false),
       org: this.org,
       project: this.project,

--- a/src/commands/force/source/push.ts
+++ b/src/commands/force/source/push.ts
@@ -22,6 +22,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages: Messages = Messages.loadMessages('@salesforce/plugin-source', 'push');
 
 export default class Push extends DeployCommand {
+  public static aliases = ['force:source:beta:push'];
   public static description = messages.getMessage('description');
   public static help = messages.getMessage('help');
   protected static readonly flagsConfig: FlagsConfig = {

--- a/src/commands/force/source/push.ts
+++ b/src/commands/force/source/push.ts
@@ -9,14 +9,14 @@ import { flags, FlagsConfig } from '@salesforce/command';
 import { Duration, env } from '@salesforce/kit';
 import { Messages } from '@salesforce/core';
 import { DeployResult, RequestStatus } from '@salesforce/source-deploy-retrieve';
-import { replaceRenamedCommands, SourceTracking } from '@salesforce/source-tracking';
+import { SourceTracking } from '@salesforce/source-tracking';
 import { getBoolean } from '@salesforce/ts-types';
-import { DeployCommand, getVersionMessage } from '../../../../deployCommand';
-import { PushResponse, PushResultFormatter } from '../../../../formatters/source/pushResultFormatter';
-import { ProgressFormatter } from '../../../../formatters/progressFormatter';
-import { DeployProgressBarFormatter } from '../../../../formatters/deployProgressBarFormatter';
-import { DeployProgressStatusFormatter } from '../../../../formatters/deployProgressStatusFormatter';
-import { trackingSetup, updateTracking } from '../../../../trackingFunctions';
+import { DeployCommand, getVersionMessage } from '../../../deployCommand';
+import { PushResponse, PushResultFormatter } from '../../../formatters/source/pushResultFormatter';
+import { ProgressFormatter } from '../../../formatters/progressFormatter';
+import { DeployProgressBarFormatter } from '../../../formatters/deployProgressBarFormatter';
+import { DeployProgressStatusFormatter } from '../../../formatters/deployProgressStatusFormatter';
+import { trackingSetup, updateTracking } from '../../../trackingFunctions';
 
 Messages.importMessagesDirectory(__dirname);
 const messages: Messages = Messages.loadMessages('@salesforce/plugin-source', 'push');
@@ -64,7 +64,7 @@ export default class Push extends DeployCommand {
 
   protected async prechecks(): Promise<void> {
     this.tracking = await trackingSetup({
-      commandName: replaceRenamedCommands('force:source:push'),
+      commandName: 'force:source:push',
       ignoreConflicts: this.getFlag<boolean>('forceoverwrite', false),
       org: this.org,
       project: this.project,

--- a/src/commands/force/source/status.ts
+++ b/src/commands/force/source/status.ts
@@ -8,9 +8,9 @@
 import * as os from 'os';
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
-import { ChangeResult, replaceRenamedCommands, StatusOutputRow, throwIfInvalid } from '@salesforce/source-tracking';
-import { StatusFormatter, StatusResult } from '../../../../formatters/source/statusFormatter';
-import { trackingSetup } from '../../../../trackingFunctions';
+import { ChangeResult, StatusOutputRow } from '@salesforce/source-tracking';
+import { StatusFormatter, StatusResult } from '../../../formatters/source/statusFormatter';
+import { trackingSetup } from '../../../trackingFunctions';
 
 Messages.importMessagesDirectory(__dirname);
 const messages: Messages = Messages.loadMessages('@salesforce/plugin-source', 'status');
@@ -41,11 +41,13 @@ export default class Status extends SfdxCommand {
   protected localAdds: ChangeResult[] = [];
 
   public async run(): Promise<StatusResult[]> {
-    throwIfInvalid({
+    const tracking = await trackingSetup({
+      commandName: 'force:source:status',
+      ignoreConflicts: true,
       org: this.org,
-      projectPath: this.project.getPath(),
-      toValidate: 'plugin-source',
-      command: replaceRenamedCommands('force:source:status'),
+      project: this.project,
+      ux: this.ux,
+      apiVersion: this.flags.apiversion as string,
     });
 
     const wantsLocal = (this.flags.local as boolean) || (!this.flags.remote && !this.flags.local);
@@ -57,14 +59,7 @@ export default class Status extends SfdxCommand {
         .map((dir) => dir.path)
         .join(',')}`
     );
-    const tracking = await trackingSetup({
-      commandName: replaceRenamedCommands('force:source:status'),
-      ignoreConflicts: true,
-      org: this.org,
-      project: this.project,
-      ux: this.ux,
-      apiVersion: this.flags.apiversion as string,
-    });
+
     const stlStatusResult = await tracking.getStatus({ local: wantsLocal, remote: wantsRemote });
     this.results = stlStatusResult.map((result) => resultConverter(result));
 

--- a/src/commands/force/source/status.ts
+++ b/src/commands/force/source/status.ts
@@ -16,6 +16,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages: Messages = Messages.loadMessages('@salesforce/plugin-source', 'status');
 
 export default class Status extends SfdxCommand {
+  public static aliases = ['force:source:beta:status'];
   public static description = messages.getMessage('description');
   public static readonly examples = messages.getMessage('examples').split(os.EOL);
   protected static flagsConfig: FlagsConfig = {

--- a/src/commands/force/source/tracking/clear.ts
+++ b/src/commands/force/source/tracking/clear.ts
@@ -8,7 +8,7 @@
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
 import * as chalk from 'chalk';
-import { replaceRenamedCommands, SourceTracking, throwIfInvalid } from '@salesforce/source-tracking';
+import { SourceTracking, throwIfInvalid } from '@salesforce/source-tracking';
 
 Messages.importMessagesDirectory(__dirname);
 const messages: Messages = Messages.loadMessages('@salesforce/plugin-source', 'tracking');
@@ -18,7 +18,7 @@ export type SourceTrackingClearResult = {
 };
 
 export class Clear extends SfdxCommand {
-  public static readonly description = replaceRenamedCommands(messages.getMessage('clearDescription'));
+  public static readonly description = messages.getMessage('clearDescription');
 
   public static readonly requiresProject = true;
   public static readonly requiresUsername = true;
@@ -36,13 +36,10 @@ export class Clear extends SfdxCommand {
       org: this.org,
       projectPath: this.project.getPath(),
       toValidate: 'plugin-source',
-      command: replaceRenamedCommands('force:source:tracking:clear'),
+      command: 'force:source:tracking:clear',
     });
     let clearedFiles: string[] = [];
-    if (
-      this.flags.noprompt ||
-      (await this.ux.confirm(chalk.dim(replaceRenamedCommands(messages.getMessage('promptMessage')))))
-    ) {
+    if (this.flags.noprompt || (await this.ux.confirm(chalk.dim(messages.getMessage('promptMessage'))))) {
       const sourceTracking = await SourceTracking.create({
         project: this.project,
         org: this.org,

--- a/src/commands/force/source/tracking/clear.ts
+++ b/src/commands/force/source/tracking/clear.ts
@@ -18,8 +18,8 @@ export type SourceTrackingClearResult = {
 };
 
 export class Clear extends SfdxCommand {
+  public static aliases = ['force:source:beta:tracking:clear'];
   public static readonly description = messages.getMessage('clearDescription');
-
   public static readonly requiresProject = true;
   public static readonly requiresUsername = true;
 

--- a/src/commands/force/source/tracking/reset.ts
+++ b/src/commands/force/source/tracking/reset.ts
@@ -19,8 +19,8 @@ export type SourceTrackingResetResult = {
 };
 
 export class Reset extends SfdxCommand {
+  public static aliases = ['force:source:beta:tracking:reset'];
   public static readonly description = messages.getMessage('resetDescription');
-
   public static readonly requiresProject = true;
   public static readonly requiresUsername = true;
 

--- a/src/commands/force/source/tracking/reset.ts
+++ b/src/commands/force/source/tracking/reset.ts
@@ -8,7 +8,7 @@
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { Messages } from '@salesforce/core';
 import * as chalk from 'chalk';
-import { replaceRenamedCommands, SourceTracking, throwIfInvalid } from '@salesforce/source-tracking';
+import { SourceTracking, throwIfInvalid } from '@salesforce/source-tracking';
 
 Messages.importMessagesDirectory(__dirname);
 const messages: Messages = Messages.loadMessages('@salesforce/plugin-source', 'tracking');
@@ -19,7 +19,7 @@ export type SourceTrackingResetResult = {
 };
 
 export class Reset extends SfdxCommand {
-  public static readonly description = replaceRenamedCommands(messages.getMessage('resetDescription'));
+  public static readonly description = messages.getMessage('resetDescription');
 
   public static readonly requiresProject = true;
   public static readonly requiresUsername = true;
@@ -41,13 +41,10 @@ export class Reset extends SfdxCommand {
       org: this.org,
       projectPath: this.project.getPath(),
       toValidate: 'plugin-source',
-      command: replaceRenamedCommands('force:source:tracking:clear'),
+      command: 'force:source:tracking:clear',
     });
 
-    if (
-      this.flags.noprompt ||
-      (await this.ux.confirm(chalk.dim(replaceRenamedCommands(messages.getMessage('promptMessage')))))
-    ) {
+    if (this.flags.noprompt || (await this.ux.confirm(chalk.dim(messages.getMessage('promptMessage'))))) {
       const sourceTracking = await SourceTracking.create({
         project: this.project,
         org: this.org,

--- a/src/trackingFunctions.ts
+++ b/src/trackingFunctions.ts
@@ -9,7 +9,6 @@ import { UX } from '@salesforce/command';
 import {
   ChangeResult,
   getTrackingFileVersion,
-  replaceRenamedCommands,
   SourceTracking,
   SourceTrackingOptions,
   throwIfInvalid,
@@ -77,13 +76,13 @@ export const filterConflictsByComponentSet = async ({
 export const trackingSetup = async (options: TrackingSetupRequest): Promise<SourceTracking> => {
   const { ux, org, ignoreConflicts, commandName, ...createOptions } = options;
   const projectPath = options.project.getPath();
-  // 2 commands use throwIfInvalid
+  // 3 commands use throwIfInvalid
   if (commandName.endsWith('push') || commandName.endsWith('pull') || commandName.endsWith('status')) {
     throwIfInvalid({
       org,
       projectPath,
       toValidate: 'plugin-source',
-      command: replaceRenamedCommands(commandName),
+      command: commandName,
     });
   } else {
     // confirm tracking file version is plugin-source for all --tracksource flags (deploy, retrieve, delete)
@@ -92,7 +91,7 @@ export const trackingSetup = async (options: TrackingSetupRequest): Promise<Sour
         'You cannot use the "tracksource" flag with the old version of the tracking files',
         'sourceTrackingFileVersionMismatch',
         [
-          'Clear the old version of the tracking files with "sfdx force:source:tracking:clear"',
+          'Clear the old version of the tracking files with "sfdx force:source:legacy:tracking:clear"',
           'Create a new org to use the new tracking files',
         ]
       );

--- a/test/nuts/trackingCommands/basics.nut.ts
+++ b/test/nuts/trackingCommands/basics.nut.ts
@@ -11,7 +11,6 @@ import { expect } from 'chai';
 import * as shelljs from 'shelljs';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { ComponentStatus, FileResponse } from '@salesforce/source-deploy-retrieve';
-import { replaceRenamedCommands } from '@salesforce/source-tracking';
 import { PushResponse } from '../../../src/formatters/source/pushResultFormatter';
 import { StatusResult } from '../../../src/formatters/source/statusFormatter';
 import { PullResponse } from '../../../src/formatters/source/pullFormatter';
@@ -39,7 +38,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
 
   describe('basic status and pull', () => {
     it('detects the initial metadata status', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(result).to.be.an.instanceof(Array);
@@ -47,7 +46,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       expect(result.every((row) => row.type && row.fullName)).to.equal(true);
     });
     it('pushes the initial metadata to the org', () => {
-      const result = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+      const result = execCmd<PushResponse>('force:source:push --json', {
         ensureExitCode: 0,
       }).jsonOutput.result.pushedSource;
       expect(result).to.be.an.instanceof(Array);
@@ -58,19 +57,19 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       ).to.equal(true);
     });
     it('sees no local changes (all were committed from push), but profile updated in remote', () => {
-      const localResult = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --local'), {
+      const localResult = execCmd<StatusResult[]>('force:source:status --json --local', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(localResult).to.deep.equal([]);
 
-      const remoteResult = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --remote'), {
+      const remoteResult = execCmd<StatusResult[]>('force:source:status --json --remote', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(remoteResult.some((item) => item.type === 'Profile')).to.equal(true);
     });
 
     it('can pull the remote profile', () => {
-      const pullResult = execCmd<PullResponse>(replaceRenamedCommands('force:source:pull --json'), {
+      const pullResult = execCmd<PullResponse>('force:source:pull --json', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(
@@ -80,7 +79,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
     });
 
     it('sees no local or remote changes', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(
@@ -95,7 +94,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
         fs.promises.unlink(path.join(classDir, 'TestOrderController.cls')),
         fs.promises.unlink(path.join(classDir, 'TestOrderController.cls-meta.xml')),
       ]);
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --local'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json --local', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(result).to.deep.equal([
@@ -120,7 +119,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       ]);
     });
     it('does not see any change in remote status', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --remote'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json --remote', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(
@@ -130,13 +129,13 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
     });
 
     it('pushes the local delete to the org', () => {
-      const result = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+      const result = execCmd<PushResponse>('force:source:push --json', {
         ensureExitCode: 0,
       }).jsonOutput.result.pushedSource;
       expect(result, JSON.stringify(result)).to.be.an.instanceof(Array).with.length(2);
     });
     it('sees no local changes', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --local'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json --local', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(result, JSON.stringify(result)).to.be.an.instanceof(Array).with.length(0);
@@ -150,7 +149,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
           result: [{ location: string; value: string }];
         }
       ).result.find((config) => config.location === 'Local').value;
-      const failure = execCmd(replaceRenamedCommands(`force:source:status -u ${hubUsername} --remote --json`), {
+      const failure = execCmd(`force:source:status -u ${hubUsername} --remote --json`, {
         ensureExitCode: 1,
       }).jsonOutput as unknown as { name: string };
       expect(failure.name).to.equal('NonSourceTrackedOrgError');
@@ -172,7 +171,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
         ]);
       });
       it('fails to push', () => {
-        const failure = execCmd(replaceRenamedCommands('force:source:push --json'), {
+        const failure = execCmd('force:source:push --json', {
           ensureExitCode: 1,
         }).jsonOutput as unknown as { name: string; exitCode: number; result: FileResponse[]; data: FileResponse[] };
         expect(failure).to.have.property('exitCode', 1);
@@ -191,7 +190,7 @@ describe('end-to-end-test for tracking with an org (single packageDir)', () => {
       });
       it('classes that failed to deploy are still in local status', () => {
         it('sees no local changes', () => {
-          const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --local'), {
+          const result = execCmd<StatusResult[]>('force:source:status --json --local', {
             ensureExitCode: 0,
           }).jsonOutput.result;
           expect(result, JSON.stringify(result)).to.be.an.instanceof(Array).with.length(2);

--- a/test/nuts/trackingCommands/conflicts.nut.ts
+++ b/test/nuts/trackingCommands/conflicts.nut.ts
@@ -15,7 +15,6 @@ import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { AuthInfo, Connection } from '@salesforce/core';
 import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
-import { replaceRenamedCommands } from '@salesforce/source-tracking';
 import { PushResponse } from '../../../src/formatters/source/pushResultFormatter';
 import { StatusResult } from '../../../src/formatters/source/statusFormatter';
 import { PullResponse } from '../../../src/formatters/source/pullFormatter';
@@ -38,7 +37,7 @@ describe('conflict detection and resolution', () => {
 
   it('pushes to initiate the remote', () => {
     // This would go in setupCommands but we want it to use the bin/run version
-    const pushResult = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+    const pushResult = execCmd<PushResponse>('force:source:push --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.pushedSource;
     expect(pushResult, JSON.stringify(pushResult)).to.have.lengthOf(231);
@@ -67,7 +66,7 @@ describe('conflict detection and resolution', () => {
         description: 'modified',
       },
     });
-    const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --remote'), {
+    const result = execCmd<StatusResult[]>('force:source:status --json --remote', {
       ensureExitCode: 0,
     }).jsonOutput.result;
     expect(
@@ -90,7 +89,7 @@ describe('conflict detection and resolution', () => {
     );
   });
   it('can see the conflict in status', () => {
-    const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+    const result = execCmd<StatusResult[]>('force:source:status --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.filter((app) => app.type === 'CustomApplication');
     // json is not sorted.  This relies on the implementation of getConflicts()
@@ -119,12 +118,12 @@ describe('conflict detection and resolution', () => {
   });
 
   it('gets conflict error on push', () => {
-    execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), { ensureExitCode: 1 });
+    execCmd<PushResponse>('force:source:push --json', { ensureExitCode: 1 });
   });
   it('gets conflict error on pull', () => {
-    execCmd<PullResponse>(replaceRenamedCommands('force:source:pull --json'), { ensureExitCode: 1 });
+    execCmd<PullResponse>('force:source:pull --json', { ensureExitCode: 1 });
   });
   it('can push with forceoverwrite', () => {
-    execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json --forceoverwrite'), { ensureExitCode: 0 });
+    execCmd<PushResponse>('force:source:push --json --forceoverwrite', { ensureExitCode: 0 });
   });
 });

--- a/test/nuts/trackingCommands/deployRetrieveDelete.nut.ts
+++ b/test/nuts/trackingCommands/deployRetrieveDelete.nut.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
-import { replaceRenamedCommands } from '@salesforce/source-tracking';
 import { StatusResult } from '../../../src/formatters/source/statusFormatter';
 import { RetrieveCommandResult } from '../../../src/formatters/retrieveResultFormatter';
 import { DeployCommandResult } from '../../../src/formatters/deployResultFormatter';
@@ -32,7 +31,7 @@ describe('-t flag for deploy, retrieve, and delete', () => {
 
   describe('basic status and deploy', () => {
     it('detects the initial metadata status', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(result).to.be.an.instanceof(Array);
@@ -51,12 +50,12 @@ describe('-t flag for deploy, retrieve, and delete', () => {
       ).to.equal(true);
     });
     it('sees no local changes (all were committed from deploy), but profile updated in remote', () => {
-      const localResult = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --local'), {
+      const localResult = execCmd<StatusResult[]>('force:source:status --json --local', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(localResult).to.deep.equal([]);
 
-      const remoteResult = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --remote'), {
+      const remoteResult = execCmd<StatusResult[]>('force:source:status --json --remote', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(remoteResult.some((item) => item.type === 'Profile')).to.equal(true);
@@ -74,7 +73,7 @@ describe('-t flag for deploy, retrieve, and delete', () => {
     });
 
     it('sees no local or remote changes', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(
@@ -93,7 +92,7 @@ describe('-t flag for deploy, retrieve, and delete', () => {
     });
 
     it('sees no local or remote changes', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       // this delete WILL change the admin profile, so remove that from the status result

--- a/test/nuts/trackingCommands/forceIgnore.nut.ts
+++ b/test/nuts/trackingCommands/forceIgnore.nut.ts
@@ -17,7 +17,6 @@ import * as shell from 'shelljs';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { AuthInfo, Connection } from '@salesforce/core';
 import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
-import { replaceRenamedCommands } from '@salesforce/source-tracking';
 import { PushResponse } from '../../../src/formatters/source/pushResultFormatter';
 import { PullResponse } from '../../../src/formatters/source/pullFormatter';
 import { StatusResult } from '../../../src/formatters/source/statusFormatter';
@@ -57,14 +56,14 @@ describe('forceignore changes', () => {
       const newForceIgnore = originalForceIgnore + '\n' + `${classdir}/IgnoreTest.cls`;
       await fs.promises.writeFile(path.join(session.project.dir, '.forceignore'), newForceIgnore);
       // nothing should push
-      const output = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+      const output = execCmd<PushResponse>('force:source:push --json', {
         ensureExitCode: 0,
       }).jsonOutput.result.pushedSource;
       expect(output).to.deep.equal([]);
     });
 
     it('shows the file in status as ignored', () => {
-      const output = execCmd<StatusResult>(replaceRenamedCommands('force:source:status --json'), {
+      const output = execCmd<StatusResult>('force:source:status --json', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(output, JSON.stringify(output)).to.deep.include({
@@ -91,7 +90,7 @@ describe('forceignore changes', () => {
         silent: true,
       });
       // pushes with no results
-      const ignoredOutput = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+      const ignoredOutput = execCmd<PushResponse>('force:source:push --json', {
         ensureExitCode: 0,
       }).jsonOutput.result.pushedSource;
       // nothing should have been pushed
@@ -103,7 +102,7 @@ describe('forceignore changes', () => {
       await fs.promises.writeFile(path.join(session.project.dir, '.forceignore'), originalForceIgnore);
 
       // verify file pushed in results
-      const unIgnoredOutput = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+      const unIgnoredOutput = execCmd<PushResponse>('force:source:push --json', {
         ensureExitCode: 0,
       }).jsonOutput.result.pushedSource;
 
@@ -136,13 +135,13 @@ describe('forceignore changes', () => {
       );
 
       // gets file into source tracking
-      const statusOutput = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --remote'), {
+      const statusOutput = execCmd<StatusResult[]>('force:source:status --json --remote', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(statusOutput.some((result) => result.fullName === 'CreatedClass')).to.equal(true);
 
       // pull doesn't retrieve that change
-      const pullOutput = execCmd<PullResponse>(replaceRenamedCommands('force:source:pull --json'), {
+      const pullOutput = execCmd<PullResponse>('force:source:pull --json', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(pullOutput.pulledSource.some((result) => result.fullName === 'CreatedClass')).to.equal(false);

--- a/test/nuts/trackingCommands/lwc.nut.ts
+++ b/test/nuts/trackingCommands/lwc.nut.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-import { replaceRenamedCommands } from '@salesforce/source-tracking';
 import { PushResponse } from '../../../src/formatters/source/pushResultFormatter';
 import { StatusResult } from '../../../src/formatters/source/statusFormatter';
 
@@ -36,7 +35,7 @@ describe('lwc', () => {
   });
 
   it('pushes the repo to get source tracking started', () => {
-    execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+    execCmd<PushResponse>('force:source:push --json', {
       ensureExitCode: 0,
     });
   });
@@ -46,14 +45,14 @@ describe('lwc', () => {
       cssPathAbsolute,
       (await fs.promises.readFile(cssPathAbsolute, 'utf-8')).replace('absolute', 'relative')
     );
-    const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+    const result = execCmd<StatusResult[]>('force:source:status --json', {
       ensureExitCode: 0,
     }).jsonOutput.result;
     expect(result.find((r) => r.filePath === cssPathRelative)).to.have.property('actualState', 'Changed');
   });
 
   it('pushes lwc css change', () => {
-    const result = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+    const result = execCmd<PushResponse>('force:source:push --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.pushedSource;
     // we get a result for each bundle member, even though only one changed
@@ -61,7 +60,7 @@ describe('lwc', () => {
   });
 
   it('sees no local changes', () => {
-    const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+    const result = execCmd<StatusResult[]>('force:source:status --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.filter((r) => r.origin === 'Local');
     expect(result).to.have.length(0);
@@ -69,7 +68,7 @@ describe('lwc', () => {
 
   it("deleting an lwc sub-component should show the sub-component as 'Deleted'", async () => {
     await fs.promises.rm(cssPathAbsolute);
-    const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+    const result = execCmd<StatusResult[]>('force:source:status --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.find((r) => r.filePath === cssPathRelative);
     expect(result).to.deep.equal({
@@ -85,7 +84,7 @@ describe('lwc', () => {
   });
 
   it('pushes lwc subcomponent delete', () => {
-    const result = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+    const result = execCmd<PushResponse>('force:source:push --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.pushedSource;
     const bundleMembers = result.filter((r) => r.fullName === 'heroDetails');
@@ -95,7 +94,7 @@ describe('lwc', () => {
   });
 
   it('sees no local changes', () => {
-    const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+    const result = execCmd<StatusResult[]>('force:source:status --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.filter((r) => r.origin === 'Local');
     expect(result).to.have.length(0);
@@ -114,7 +113,7 @@ describe('lwc', () => {
       dependentLWCPath,
       (await fs.promises.readFile(dependentLWCPath, 'utf-8')).replace(/<c-hero.*hero-details>/s, '')
     );
-    const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+    const result = execCmd<StatusResult[]>('force:source:status --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.filter((r) => r.origin === 'Local');
     expect(result).to.have.length(4);
@@ -123,7 +122,7 @@ describe('lwc', () => {
   });
 
   it('push deletes the LWC remotely', () => {
-    const result = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+    const result = execCmd<PushResponse>('force:source:push --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.pushedSource;
     // there'll also be changes for the changed Hero component html, but we've already tested changing a bundle member
@@ -136,7 +135,7 @@ describe('lwc', () => {
   });
 
   it('sees no local changes', () => {
-    const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+    const result = execCmd<StatusResult[]>('force:source:status --json', {
       ensureExitCode: 0,
     }).jsonOutput.result.filter((r) => r.origin === 'Local');
     expect(result).to.have.length(0);

--- a/test/nuts/trackingCommands/mpd-non-sequential.nut.ts
+++ b/test/nuts/trackingCommands/mpd-non-sequential.nut.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import { AuthInfo, Connection } from '@salesforce/core';
 import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-import { replaceRenamedCommands } from '@salesforce/source-tracking';
 import { PushResponse } from '../../../src/formatters/source/pushResultFormatter';
 
 let session: TestSession;
@@ -38,7 +37,7 @@ describe('multiple pkgDirectories pushed as one deploy', () => {
 
   describe('mpd non-sequential', () => {
     it('pushes using MPD', () => {
-      const result = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+      const result = execCmd<PushResponse>('force:source:push --json', {
         ensureExitCode: 0,
       }).jsonOutput.result.pushedSource;
       expect(result).to.be.an.instanceof(Array);

--- a/test/nuts/trackingCommands/mpd-sequential.nut.ts
+++ b/test/nuts/trackingCommands/mpd-sequential.nut.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import { AuthInfo, Connection, fs } from '@salesforce/core';
 import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
-import { replaceRenamedCommands } from '@salesforce/source-tracking';
 import { PushResponse } from '../../../src/formatters/source/pushResultFormatter';
 
 let session: TestSession;
@@ -48,7 +47,7 @@ describe('multiple pkgDirs deployed sequentially', () => {
 
   describe('mpd sequential', () => {
     it('pushes using MPD', () => {
-      const result = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+      const result = execCmd<PushResponse>('force:source:push --json', {
         ensureExitCode: 0,
       }).jsonOutput.result.pushedSource;
       expect(result).to.be.an.instanceof(Array);

--- a/test/nuts/trackingCommands/remoteChanges.nut.ts
+++ b/test/nuts/trackingCommands/remoteChanges.nut.ts
@@ -16,7 +16,6 @@ import { expect } from 'chai';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { AuthInfo, Connection } from '@salesforce/core';
 import { ComponentStatus } from '@salesforce/source-deploy-retrieve';
-import { replaceRenamedCommands } from '@salesforce/source-tracking';
 import { PushResponse } from '../../../src/formatters/source/pushResultFormatter';
 import { StatusResult } from '../../../src/formatters/source/statusFormatter';
 import { PullResponse } from '../../../src/formatters/source/pullFormatter';
@@ -46,7 +45,7 @@ describe('remote changes', () => {
 
   describe('remote changes: delete', () => {
     it('pushes to initiate the remote', () => {
-      const pushResult = execCmd<PushResponse>(replaceRenamedCommands('force:source:push --json'), {
+      const pushResult = execCmd<PushResponse>('force:source:push --json', {
         ensureExitCode: 0,
       }).jsonOutput.result.pushedSource;
       expect(pushResult, JSON.stringify(pushResult)).to.have.lengthOf(231);
@@ -81,7 +80,7 @@ describe('remote changes', () => {
       ).to.equal(true);
     });
     it('can see the delete in status', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --remote'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json --remote', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       // it shows up as one class on the server, but 2 files when pulled
@@ -91,14 +90,13 @@ describe('remote changes', () => {
       ).to.have.length(1);
     });
     it('does not see any change in local status', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --local'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json --local', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(result).to.deep.equal([]);
     });
     it('can pull the delete', () => {
-      const result = execCmd<PullResponse>(replaceRenamedCommands('force:source:pull --json'), { ensureExitCode: 0 })
-        .jsonOutput.result;
+      const result = execCmd<PullResponse>('force:source:pull --json', { ensureExitCode: 0 }).jsonOutput.result;
       // the 2 files for the apexClass, and possibly one for the Profile (depending on whether it got created in time)
       expect(result.pulledSource, JSON.stringify(result)).to.have.length.greaterThanOrEqual(2);
       expect(result.pulledSource, JSON.stringify(result)).to.have.length.lessThanOrEqual(4);
@@ -119,12 +117,12 @@ describe('remote changes', () => {
       ).to.equal(false);
     });
     it('sees correct local and remote status', () => {
-      const remoteResult = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --remote'), {
+      const remoteResult = execCmd<StatusResult[]>('force:source:status --json --remote', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(remoteResult.filter((r) => r.state.includes('Remote Deleted'))).to.deep.equal([]);
 
-      const localStatus = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --local'), {
+      const localStatus = execCmd<StatusResult[]>('force:source:status --json --local', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(localStatus).to.deep.equal([]);
@@ -144,7 +142,7 @@ describe('remote changes', () => {
       }
     });
     it('can see the add in status', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --remote'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json --remote', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(
@@ -153,15 +151,14 @@ describe('remote changes', () => {
       ).to.equal(true);
     });
     it('can pull the add', () => {
-      const result = execCmd<PullResponse>(replaceRenamedCommands('force:source:pull --json'), { ensureExitCode: 0 })
-        .jsonOutput.result;
+      const result = execCmd<PullResponse>('force:source:pull --json', { ensureExitCode: 0 }).jsonOutput.result;
       // SDR marks all retrieves as 'Changed' even if it creates new local files.  This is different from toolbelt, which marked those as 'Created'
       result.pulledSource
         .filter((r) => r.fullName === className)
         .map((r) => expect(r.state, JSON.stringify(r)).to.equal('Created'));
     });
     it('sees correct local and remote status', () => {
-      const remoteResult = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --remote'), {
+      const remoteResult = execCmd<StatusResult[]>('force:source:status --json --remote', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(
@@ -169,7 +166,7 @@ describe('remote changes', () => {
         JSON.stringify(remoteResult)
       ).deep.equal([]);
 
-      const localStatus = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json --local'), {
+      const localStatus = execCmd<StatusResult[]>('force:source:status --json --local', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(localStatus).to.deep.equal([]);

--- a/test/nuts/trackingCommands/resetClear.nut.ts
+++ b/test/nuts/trackingCommands/resetClear.nut.ts
@@ -14,9 +14,8 @@ import * as fs from 'fs';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { expect } from 'chai';
 import { AuthInfo, Connection } from '@salesforce/core';
-import { replaceRenamedCommands } from '@salesforce/source-tracking';
 import { StatusResult } from '../../../src/formatters/source/statusFormatter';
-import { SourceTrackingClearResult } from '../../../src/commands/force/source/beta/tracking/clear';
+import { SourceTrackingClearResult } from '../../../src/commands/force/source/tracking/clear';
 
 let session: TestSession;
 let orgId: string;
@@ -62,7 +61,7 @@ describe('reset and clear', () => {
 
   describe('clearing tracking', () => {
     it('runs status to start tracking', () => {
-      const result = execCmd<StatusResult[]>(replaceRenamedCommands('force:source:status --json'), {
+      const result = execCmd<StatusResult[]>('force:source:status --json', {
         ensureExitCode: 0,
       }).jsonOutput.result;
       expect(result).to.have.length.greaterThan(100); // ebikes is big
@@ -75,12 +74,9 @@ describe('reset and clear', () => {
       expect(fs.existsSync(path.join(trackingFileFolder, 'maxRevision.json'))).to.equal(true);
     });
     it('runs clear', () => {
-      const clearResult = execCmd<SourceTrackingClearResult>(
-        replaceRenamedCommands('force:source:tracking:clear --noprompt --json'),
-        {
-          ensureExitCode: 0,
-        }
-      ).jsonOutput.result;
+      const clearResult = execCmd<SourceTrackingClearResult>('force:source:tracking:clear --noprompt --json', {
+        ensureExitCode: 0,
+      }).jsonOutput.result;
       expect(clearResult.clearedFiles.some((file) => file.includes('maxRevision.json'))).to.equal(true);
     });
     it('local tracking is gone', () => {
@@ -110,7 +106,7 @@ describe('reset and clear', () => {
         }
       });
       // gets tracking files from server
-      execCmd(replaceRenamedCommands('force:source:status --json --remote'), { ensureExitCode: 0 });
+      execCmd('force:source:status --json --remote', { ensureExitCode: 0 });
       const revisions = await getRevisionsAsArray();
       const revisionFile = JSON.parse(
         await fs.promises.readFile(path.join(trackingFileFolder, 'maxRevision.json'), 'utf8')
@@ -127,7 +123,7 @@ describe('reset and clear', () => {
       });
     });
     it('can reset to a known revision', async () => {
-      execCmd(replaceRenamedCommands(`force:source:tracking:reset --revision ${lowestRevision} --noprompt`), {
+      execCmd(`force:source:tracking:reset --revision ${lowestRevision} --noprompt`, {
         ensureExitCode: 0,
       });
       const revisions = await getRevisionsAsArray();
@@ -140,7 +136,7 @@ describe('reset and clear', () => {
     });
 
     it('can reset to a non-specified revision (resets everything)', async () => {
-      execCmd(replaceRenamedCommands(`force:source:tracking:reset --revision ${lowestRevision} --noprompt`), {
+      execCmd(`force:source:tracking:reset --revision ${lowestRevision} --noprompt`, {
         ensureExitCode: 0,
       });
       const revisions = await getRevisionsAsArray();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,15 +1012,15 @@
     sinon "^10.0.0"
     strip-ansi "^6.0.0"
 
-"@salesforce/source-tracking@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-tracking/-/source-tracking-1.1.3.tgz#fd553a9c6f4b7bf06c6d3cc71d06b2ed022c5de7"
-  integrity sha512-8LpR2bR2nCm+IKF+nPJ1msO2yyE1CQNPie9EdQQH1/JenwHduw3jo/TzAL7Fszx6Lu3swOrYOGbK8AgbYvQRPg==
+"@salesforce/source-tracking@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-tracking/-/source-tracking-1.2.0.tgz#3a64ce059dffbfaae2871e4197260b34ca8bfe59"
+  integrity sha512-7kVD5dXg0ksIYmsZxDfo9qcpOjFiEjNEH3GY5liYDeAatQPKyjKuvRtjeY5NLbblpvZiu2yjLLSACpKq0B1vWw==
   dependencies:
     "@salesforce/core" "^2.33.1"
     "@salesforce/kit" "^1.5.17"
     "@salesforce/source-deploy-retrieve" "^5.9.4"
-    isomorphic-git "^1.9.2"
+    isomorphic-git "1.16.0"
     ts-retry-promise "^0.6.0"
 
 "@salesforce/ts-sinon@1.3.21":
@@ -4839,10 +4839,10 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-git@^1.9.2:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-git/-/isomorphic-git-1.11.1.tgz#d0b8858c2a10fd849850de860d59ebc7685b2735"
-  integrity sha512-SUjsx//K0HPk7wnUOOkp13/PjyfY9XsLJq6KG2OVqimykdzC2OtTM9IFlXIPuU1vQa0NjzmmJLlygCx8narvUg==
+isomorphic-git@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-git/-/isomorphic-git-1.16.0.tgz#f4de2fd0e1c78bbbe03230fbefa88a84463e736a"
+  integrity sha512-pyYcMRp0125hmxsagSaAN63WgHd4x+4sR3eJ71+xdIN0aOij0q5ASPIN7jiJissUHx9/FE4dY73pzDehk+Xomw==
   dependencies:
     async-lock "^1.1.0"
     clean-git-ref "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,7 +514,7 @@
     is-wsl "^2.1.1"
     tslib "^2.0.0"
 
-"@oclif/config@^1", "@oclif/config@^1.17.1", "@oclif/config@^1.18.1", "@oclif/config@^1.18.2":
+"@oclif/config@^1", "@oclif/config@^1.17.1", "@oclif/config@^1.18.1", "@oclif/config@^1.18.2", "@oclif/config@^1.18.3":
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.18.3.tgz#ddfc144fdab66b1658c2f1b3478fa7fbfd317e79"
   integrity sha512-sBpko86IrTscc39EvHUhL+c++81BVTsIZ3ETu/vG+cCdi0N6vb2DoahR67A9FI2CGnxRRHjnTfa3m6LulwNATA==


### PR DESCRIPTION
requires https://github.com/forcedotcom/source-tracking/pull/136
should go out with https://github.com/salesforcecli/toolbelt/pull/225

### What does this PR do?
GA the new versions of the tracking commands
prevents some edge cases of undefined that would cause problems for cli-ux/table


### What issues does this PR fix or reference?
2nd try at [@W-10830392@](https://gus.lightning.force.com/a07EE00000sWQDXYA4)