### PR TITLE
fix: pull non-default directory in default project

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,8 +9,7 @@
       "request": "attach",
       "name": "Attach",
       "port": 9229,
-      "skipFiles": ["<node_internals>/**"],
-      "continueOnAttach": true
+      "skipFiles": ["<node_internals>/**"]
     },
     {
       "name": "Run All Tests",

--- a/src/commands/force/source/pull.ts
+++ b/src/commands/force/source/pull.ts
@@ -8,14 +8,8 @@
 import { flags, FlagsConfig } from '@salesforce/command';
 import { Duration } from '@salesforce/kit';
 import { Messages } from '@salesforce/core';
-import {
-  ComponentSet,
-  FileResponse,
-  RequestStatus,
-  RetrieveResult,
-  SourceComponent,
-} from '@salesforce/source-deploy-retrieve';
-import { ChangeResult, SourceTracking } from '@salesforce/source-tracking';
+import { FileResponse, RequestStatus, RetrieveResult, SourceComponent } from '@salesforce/source-deploy-retrieve';
+import { SourceTracking } from '@salesforce/source-tracking';
 import { SourceCommand } from '../../../sourceCommand';
 import { PullResponse, PullResultFormatter } from '../../../formatters/source/pullFormatter';
 import { trackingSetup, updateTracking } from '../../../trackingFunctions';
@@ -85,22 +79,9 @@ export default class Pull extends SourceCommand {
   }
 
   protected async retrieve(): Promise<void> {
-    const componentSet = new ComponentSet();
-    (
-      await this.tracking.getChanges<ChangeResult>({
-        origin: 'remote',
-        state: 'nondelete',
-        format: 'ChangeResult',
-      })
-    ).map((component) => {
-      if (component.type && component.name) {
-        componentSet.add({
-          type: component.type,
-          fullName: component.name,
-        });
-      }
-    });
+    const componentSet = await this.tracking.remoteNonDeletesAsComponentSet();
 
+    // if it is't local, add it as a
     if (componentSet.size === 0) {
       return;
     }


### PR DESCRIPTION
### What does this PR do?
use new STL method for generating a componentSet that mixes SourceComponent (where the exist) with metadataMember (where they are remote only) to ensure that the retrieved components don't duplicate to default dir

### What issues does this PR fix or reference?
@W-11047555@
https://github.com/forcedotcom/cli/issues/1485
