### PR TITLE
fix: import coverageUtils from parent folder

### DIFF
--- a/src/formatters/deployResultFormatter.ts
+++ b/src/formatters/deployResultFormatter.ts
@@ -16,7 +16,7 @@ import {
   MetadataApiDeployStatus,
   RequestStatus,
 } from '@salesforce/source-deploy-retrieve';
-import { prepCoverageForDisplay } from '../../src/coverageUtils';
+import { prepCoverageForDisplay } from '../coverageUtils';
 import { ResultFormatter, ResultFormatterOptions, toArray } from './resultFormatter';
 import { MdDeployResult } from './mdapi/mdDeployResultFormatter';
 


### PR DESCRIPTION
### What does this PR do?
Import `coverageUtils` from parent folder instead of `../../src/`.
This is causing `sfdx` to fail because the compiled js doesn't know about the `src` folder.

### What issues does this PR fix or reference?
@W-0@
