### PR TITLE
fix: default min line number to 1 when 100 pct coverage

### DIFF
--- a/src/coverageUtils.ts
+++ b/src/coverageUtils.ts
@@ -64,8 +64,8 @@ function generateCoveredLines(cov: CodeCoverage): [number[], number[]] {
   const numCovered = parseInt(cov.numLocations, 10);
   const numUncovered = parseInt(cov.numLocationsNotCovered, 10);
   const uncoveredLines = toArray(cov.locationsNotCovered).map((location) => parseInt(location.line, 10));
-  const mminLineNumber = Math.min(...uncoveredLines);
-  const lines = [...Array(numCovered + numUncovered).keys()].map((i) => i + mminLineNumber);
+  const minLineNumber = uncoveredLines.length ? Math.min(...uncoveredLines) : 1;
+  const lines = [...Array(numCovered + numUncovered).keys()].map((i) => i + minLineNumber);
   const coveredLines = lines.filter((line) => !uncoveredLines.includes(line));
   return [uncoveredLines, coveredLines];
 }

--- a/test/coverageUtils.test.ts
+++ b/test/coverageUtils.test.ts
@@ -208,9 +208,13 @@ describe('transform md RunTestResult', () => {
     expect(apexCoverage.records).to.have.length(4);
     expect(apexCoverage.records[0].ApexClassOrTrigger.Name).to.equal('PagedResult');
     expect(apexCoverage.records[1].ApexClassOrTrigger.Name).to.equal('PropertyController');
+    expect(apexCoverage.records[2].ApexClassOrTrigger.Name).to.equal('SampleDataController');
     expect(apexCoverage.records[1].NumLinesCovered).to.equal(44);
     expect(apexCoverage.records[1].NumLinesUncovered).to.equal(3);
     expect(apexCoverage.records[1].Coverage.uncoveredLines).to.deep.equal([26, 31, 78]);
+    expect(apexCoverage.records[2].Coverage.uncoveredLines).to.have.lengthOf(0);
+    expect(apexCoverage.records[2].Coverage.uncoveredLines).to.have.lengthOf(apexCoverage.records[2].NumLinesUncovered);
+    expect(apexCoverage.records[2].Coverage.coveredLines).to.have.lengthOf(apexCoverage.records[2].NumLinesCovered);
   });
   it('should transform md test results to apex test results format', () => {
     const apexTestResults = transformDeployTestsResultsToTestResult(mockConnection, sampleRunTestResult);


### PR DESCRIPTION
### What does this PR do?
Math.min with no params is Infinity. Default to 1 when array is empty
### What issues does this PR fix or reference?
@W-11221748@