### PR TITLE
fix: isRestDeploy correctly handles org-metadata-rest-deploy config c…

### DIFF
--- a/src/commands/force/mdapi/deploy.ts
+++ b/src/commands/force/mdapi/deploy.ts
@@ -123,7 +123,7 @@ export class Deploy extends DeployCommand {
     const waitDuration = waitFlag.minutes === -1 ? Duration.days(7) : waitFlag;
 
     this.isAsync = waitDuration.quantity === 0;
-    this.isRest = await this.isRestDeploy();
+    this.isRest = this.isRestDeploy();
     if (this.isAsync && (this.flags.coverageformatters || this.flags.junit)) {
       this.warn(messages.getMessage('asyncCoverageJunitWarning'));
     }

--- a/src/commands/force/source/delete.ts
+++ b/src/commands/force/source/delete.ts
@@ -186,7 +186,7 @@ export class Delete extends DeployCommand {
 
     // fire predeploy event for the delete
     await this.lifecycle.emit('predeploy', this.components);
-    this.isRest = await this.isRestDeploy();
+    this.isRest = this.isRestDeploy();
     this.ux.log(`*** Deleting with ${this.isRest ? 'REST' : 'SOAP'} API ***`);
 
     const deploy = await this.componentSet.deploy({

--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -10,7 +10,7 @@ import { Messages } from '@salesforce/core';
 import { Duration, env } from '@salesforce/kit';
 import { SourceTracking } from '@salesforce/source-tracking';
 import { ComponentSetBuilder } from '@salesforce/source-deploy-retrieve';
-import { DeployCommand, reportsFormatters, getVersionMessage, TestLevel } from '../../../deployCommand';
+import { DeployCommand, getVersionMessage, reportsFormatters, TestLevel } from '../../../deployCommand';
 import { DeployCommandResult, DeployResultFormatter } from '../../../formatters/deployResultFormatter';
 import {
   DeployAsyncResultFormatter,
@@ -163,7 +163,7 @@ export class Deploy extends DeployCommand {
   protected async deploy(): Promise<void> {
     const waitDuration = this.getFlag<Duration>('wait');
     this.isAsync = waitDuration.quantity === 0;
-    this.isRest = await this.isRestDeploy();
+    this.isRest = this.isRestDeploy();
 
     if (this.isAsync && (this.flags.coverageformatters || this.flags.junit)) {
       this.warn(messages.getMessage('asyncCoverageJunitWarning'));

--- a/src/deployCommand.ts
+++ b/src/deployCommand.ts
@@ -8,16 +8,16 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import {
+  AsyncResult,
   ComponentSet,
   DeployResult,
   MetadataApiDeploy,
   MetadataApiDeployStatus,
   RequestStatus,
-  AsyncResult,
 } from '@salesforce/source-deploy-retrieve';
-import { ConfigAggregator, PollingClient, SfError, StatusResult, Messages } from '@salesforce/core';
+import { Messages, PollingClient, SfdxPropertyKeys, SfError, StatusResult } from '@salesforce/core';
 import { AnyJson, getBoolean, isString } from '@salesforce/ts-types';
-import { Duration, once } from '@salesforce/kit';
+import { cloneJson, Duration, once } from '@salesforce/kit';
 import {
   CoverageReporter,
   CoverageReporterOptions,
@@ -25,7 +25,6 @@ import {
   DefaultReportOptions,
   JUnitReporter,
 } from '@salesforce/apex-node';
-import { cloneJson } from '@salesforce/kit';
 import { SourceCommand } from './sourceCommand';
 import { DeployData, Stash } from './stash';
 import { transformCoverageToApexCoverage, transformDeployTestsResultsToTestResult } from './coverageUtils';
@@ -127,17 +126,16 @@ export abstract class DeployCommand extends SourceCommand {
     }
   }
 
-  // REST is the default unless:
+  // SOAP is the default unless:
   //   1. SOAP is specified with the soapdeploy flag on the command
-  //   2. The restDeploy SFDX config setting is explicitly false.
-  protected async isRestDeploy(): Promise<boolean> {
+  //   2. The restDeploy SFDX config setting is explicitly true.
+  protected isRestDeploy(): boolean {
     if (getBoolean(this.flags, 'soapdeploy') === true) {
       this.logger.debug('soapdeploy flag === true.  Using SOAP');
       return false;
     }
 
-    const aggregator = await ConfigAggregator.create();
-    const restDeployConfig = aggregator.getPropertyValue('restDeploy');
+    const restDeployConfig = this.configAggregator.getInfo(SfdxPropertyKeys.REST_DEPLOY).value;
     // aggregator property values are returned as strings
     if (restDeployConfig === 'false') {
       this.logger.debug('restDeploy SFDX config === false.  Using SOAP');


### PR DESCRIPTION
…onversion

### What does this PR do?
`isRestDeploy` method respects the sf/sfdx config value conversion

comments in the method are now correct. SOAP is default, unless the config/env var is `true`

### What issues does this PR fix or reference?
@W-11390183@