### PR TITLE
fix: try/finally on pollStatus to handle throws from timeout

### DIFF
--- a/src/commands/force/mdapi/deploy/report.ts
+++ b/src/commands/force/mdapi/deploy/report.ts
@@ -82,11 +82,9 @@ export class Report extends DeployCommand {
     );
 
     if (this.isAsync) {
-      this.deployResult = await this.report(this.getFlag<string>('jobid'));
+      this.deployResult = await this.report(deployId);
       return;
     }
-
-    this.displayDeployId(deployId);
 
     const deploy = this.createDeploy(deployId);
     if (!this.isJsonOutput()) {
@@ -95,7 +93,12 @@ export class Report extends DeployCommand {
         : new DeployProgressStatusFormatter(this.logger, this.ux);
       progressFormatter.progress(deploy);
     }
-    this.deployResult = await deploy.pollStatus({ frequency: Duration.milliseconds(500), timeout: waitDuration });
+
+    try {
+      await deploy.pollStatus({ frequency: Duration.milliseconds(500), timeout: waitDuration });
+    } finally {
+      this.deployResult = await this.report(deployId);
+    }
   }
 
   // this is different from the source:report uses report error codes (unfortunately)

--- a/src/commands/force/source/deploy/report.ts
+++ b/src/commands/force/source/deploy/report.ts
@@ -93,8 +93,11 @@ export class Report extends DeployCommand {
         : new DeployProgressStatusFormatter(this.logger, this.ux);
       progressFormatter.progress(deploy);
     }
-    await deploy.pollStatus({ timeout: waitDuration });
-    this.deployResult = await this.report(deployId);
+    try {
+      await deploy.pollStatus({ timeout: waitDuration });
+    } finally {
+      this.deployResult = await this.report(deployId);
+    }
   }
 
   // No-op implementation since any DeployResult status would be a success.


### PR DESCRIPTION
### What does this PR do?
try/finally on pollStatus for both `mdapi:deploy:report` and `source:deploy:report`
after the deploy times out, it uses the `this.report` one more time to get a good in-progress DeployResult

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1612
[@W-11431588@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000011TwIzYAK/view)


### QA notes

I used [EDA](https://github.com/mshanemc/EDA) to get a really slow deploy like the customer has

```
# eda is weird with its scratch orgs and namespace, so
sfdx force:org:create -d 1 -f orgs/dev.json --nonamespace -s
# convert source for mdapi deploy
sfdx force:source:convert -d force-app --outputdir=mdapiOut
``` 

steps based on the customer's logic.  Have these ready to copy/paste quickly
```
../../plugin-source/bin/dev force:mdapi:deploy --deploydir mdapiOut --ignorewarnings -w 0 --testlevel RunLocalTests --json
# but use the job id from your deploy
../../plugin-source/bin/dev force:mdapi:deploy:report -i 0Af1k00001PyBXhCAN --wait 1 --json
# verifying fix for source:deploy
../../plugin-source/bin/dev force:source:deploy:report -i 0Af1k00001PyBXhCAN --wait 1 --json
```
![Screen Shot 2022-07-14 at 2 35 37 PM](https://user-images.githubusercontent.com/4261788/179068573-df6b3e07-34d0-4b7f-aaaf-df8dcf5031d6.png)

