### PR TITLE
fix: exclude sourcepath from component set builder

### DIFF
--- a/src/commands/force/mdapi/retrieve.ts
+++ b/src/commands/force/mdapi/retrieve.ts
@@ -110,7 +110,7 @@ export class Retrieve extends SourceCommand {
 
   protected async retrieve(): Promise<void> {
     const packagenames = this.getFlag<string[]>('packagenames');
-    if (!packagenames) {
+    if (!packagenames && !this.flags.unpackaged) {
       this.sourceDir = this.resolveRootDir(this.getFlag<string>('sourcedir'));
     }
     this.retrieveTargetDir = this.resolveOutputDir(this.getFlag<string>('retrievetargetdir'));


### PR DESCRIPTION
### What does this PR do?
Exclude passing a sourcepath to the ComponentSetBuilder when the `unpackaged` flag is set.  The `unpackaged` flag is the path to the manifest and the command should only use the manifest, not consider any local source path.

### What issues does this PR fix or reference?
@W-11588116@