### PR TITLE
fix: only listen to events once per package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@salesforce/command": "^5.2.35",
     "@salesforce/core": "^3.32.14",
     "@salesforce/kit": "^1.8.3",
-    "@salesforce/source-deploy-retrieve": "^7.7.3",
+    "@salesforce/source-deploy-retrieve": "^7.7.5",
     "@salesforce/source-tracking": "^2.2.18",
     "chalk": "^4.1.2",
     "got": "^11.8.3",

--- a/src/commands/force/source/push.ts
+++ b/src/commands/force/source/push.ts
@@ -88,6 +88,20 @@ export default class Push extends DeployCommand {
       this.getSourceApiVersion(),
       this.isRestDeploy(),
     ]);
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    this.lifecycle.on('apiVersionDeploy', async (apiData: DeployVersionData) => {
+      this.ux.log(
+        deployMessages.getMessage('apiVersionMsgDetailed', [
+          'Pushing',
+          apiData.manifestVersion,
+          this.org.getUsername(),
+          apiData.apiVersion,
+          apiData.webService,
+        ])
+      );
+    });
+
     for (const componentSet of componentSets) {
       // intentionally to do this sequentially if there are multiple component sets
       /* eslint-disable no-await-in-loop */
@@ -107,18 +121,6 @@ export default class Push extends DeployCommand {
       await this.lifecycle.emit('predeploy', componentSet.toArray());
 
       const username = this.org.getUsername();
-      // eslint-disable-next-line @typescript-eslint/require-await
-      this.lifecycle.on('apiVersionDeploy', async (apiData: DeployVersionData) => {
-        this.ux.log(
-          deployMessages.getMessage('apiVersionMsgDetailed', [
-            'Pushing',
-            apiData.manifestVersion,
-            username,
-            apiData.apiVersion,
-            apiData.webService,
-          ])
-        );
-      });
 
       const deploy = await componentSet.deploy({
         usernameOrConnection: username,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1332,6 +1332,25 @@
     proxy-from-env "^1.1.0"
     unzipper "0.10.11"
 
+"@salesforce/source-deploy-retrieve@^7.7.5":
+  version "7.7.5"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.7.5.tgz#4eb64f02d4759f98e1e64187a081c472ebe8a2ae"
+  integrity sha512-zkGpbvTVr2nBJfbTxShFfaa4DAOvbXiaaWjZg0oVLUDoAQh+uQKX4aPdsXqJR4pKdQR8u1JwEV7TlR1f5gMCrg==
+  dependencies:
+    "@salesforce/core" "^3.32.13"
+    "@salesforce/kit" "^1.8.0"
+    "@salesforce/ts-types" "^1.7.2"
+    archiver "^5.3.1"
+    fast-xml-parser "^3.21.1"
+    got "^11.8.6"
+    graceful-fs "^4.2.10"
+    ignore "^5.2.4"
+    mime "2.6.0"
+    minimatch "^5.1.2"
+    proxy-agent "^5.0.0"
+    proxy-from-env "^1.1.0"
+    unzipper "0.10.11"
+
 "@salesforce/source-testkit@^2.0.29":
   version "2.0.29"
   resolved "https://registry.yarnpkg.com/@salesforce/source-testkit/-/source-testkit-2.0.29.tgz#394967e2028be482cae78eb0cf57a8696aee21df"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,30 +1097,7 @@
     "@salesforce/ts-types" "^1.7.1"
     chalk "^2.4.2"
 
-"@salesforce/core@^3.23.9", "@salesforce/core@^3.24.0", "@salesforce/core@^3.25.1", "@salesforce/core@^3.31.19", "@salesforce/core@^3.32.11":
-  version "3.32.12"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.32.12.tgz#853cc5b6a5f95d4896b2d34a40a6042ef9aa6d2c"
-  integrity sha512-27rqSiQWul7b/OkJs19FYDv2M/S4oI4efiGv+6sR7UWv7D7CG1P+0XpgLS3d9xRYF30h98n6VQr4W2a+BWFRvA==
-  dependencies:
-    "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.8.0"
-    "@salesforce/schemas" "^1.4.0"
-    "@salesforce/ts-types" "^1.5.21"
-    "@types/graceful-fs" "^4.1.5"
-    "@types/semver" "^7.3.13"
-    ajv "^8.11.2"
-    archiver "^5.3.0"
-    change-case "^4.1.2"
-    debug "^3.2.7"
-    faye "^1.4.0"
-    form-data "^4.0.0"
-    graceful-fs "^4.2.9"
-    js2xmlparser "^4.0.1"
-    jsforce "^2.0.0-beta.19"
-    jsonwebtoken "9.0.0"
-    ts-retry-promise "^0.7.0"
-
-"@salesforce/core@^3.32.12", "@salesforce/core@^3.32.13", "@salesforce/core@^3.32.14":
+"@salesforce/core@^3.23.9", "@salesforce/core@^3.24.0", "@salesforce/core@^3.25.1", "@salesforce/core@^3.31.19", "@salesforce/core@^3.32.11", "@salesforce/core@^3.32.12", "@salesforce/core@^3.32.13", "@salesforce/core@^3.32.14":
   version "3.32.14"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.32.14.tgz#8746656d72776f27bc2cbfba7344d4f7ddd236ca"
   integrity sha512-2hpjdYgVFdi9Bgihw8skElhbCi3U0uowrsoCNljtCHrxnm+ORyqwsdDAnNemKUPBL9JGX4ASfWcD4m7F8m9Ysw==
@@ -1187,16 +1164,7 @@
     typedoc-plugin-missing-exports "0.23.0"
     typescript "^4.1.3"
 
-"@salesforce/kit@^1.7.1", "@salesforce/kit@^1.8.0":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.8.1.tgz#289ca9f4094157c1deaa77cc72f295fdc71f043f"
-  integrity sha512-fCMKh7yWiWtl9C2OXamwkzxD7r6MddrsxKAvlMYZTrTeVG/wxrV03NIhARVkT0k12CsmWNYv83VSPobBAufiIA==
-  dependencies:
-    "@salesforce/ts-types" "^1.7.1"
-    shx "^0.3.3"
-    tslib "^2.2.0"
-
-"@salesforce/kit@^1.8.3":
+"@salesforce/kit@^1.7.1", "@salesforce/kit@^1.8.0", "@salesforce/kit@^1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.8.3.tgz#b590b78a8618494c51534598a7eb0683ba0da3f2"
   integrity sha512-p+0tWR2pyCAIjZwDXGhrYFPuLckX9fP3Xa6Jync9POeQBfDGyK9CRd1eaiWj+6BeDS9kwvgm5M6o+OptIEhEjw==
@@ -1294,45 +1262,7 @@
     chalk "^4"
     inquirer "^8.2.5"
 
-"@salesforce/source-deploy-retrieve@^7.5.19":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.7.0.tgz#30b81028f27a196e37a68b591c761db4ee53ddd3"
-  integrity sha512-Lw6+e1oxFUZgw8cArcE3wXGIJyPWC18eMIkF+oGD8ZhEEcQavAEzxLAKsYMrzZyIDXP/6dqZ5/McdJ1FAfe5BQ==
-  dependencies:
-    "@salesforce/core" "^3.32.12"
-    "@salesforce/kit" "^1.8.0"
-    "@salesforce/ts-types" "^1.7.2"
-    archiver "^5.3.1"
-    fast-xml-parser "^3.21.1"
-    got "^11.8.6"
-    graceful-fs "^4.2.10"
-    ignore "^5.2.4"
-    mime "2.6.0"
-    minimatch "^5.1.2"
-    proxy-agent "^5.0.0"
-    proxy-from-env "^1.1.0"
-    unzipper "0.10.11"
-
-"@salesforce/source-deploy-retrieve@^7.7.3":
-  version "7.7.3"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.7.3.tgz#476d4bae3cd74330ca0c65c74f7bf60999b9513d"
-  integrity sha512-CPn5AqsFLz9ZIFgL+4NmOwiizO4xWNelwdLan/aTzUqmxPo+XSZ8MYU+tD/1Pe8/fjmzLh/iYePiAMpXdphGRw==
-  dependencies:
-    "@salesforce/core" "^3.32.13"
-    "@salesforce/kit" "^1.8.0"
-    "@salesforce/ts-types" "^1.7.2"
-    archiver "^5.3.1"
-    fast-xml-parser "^3.21.1"
-    got "^11.8.6"
-    graceful-fs "^4.2.10"
-    ignore "^5.2.4"
-    mime "2.6.0"
-    minimatch "^5.1.2"
-    proxy-agent "^5.0.0"
-    proxy-from-env "^1.1.0"
-    unzipper "0.10.11"
-
-"@salesforce/source-deploy-retrieve@^7.7.5":
+"@salesforce/source-deploy-retrieve@^7.5.19", "@salesforce/source-deploy-retrieve@^7.7.3", "@salesforce/source-deploy-retrieve@^7.7.5":
   version "7.7.5"
   resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.7.5.tgz#4eb64f02d4759f98e1e64187a081c472ebe8a2ae"
   integrity sha512-zkGpbvTVr2nBJfbTxShFfaa4DAOvbXiaaWjZg0oVLUDoAQh+uQKX4aPdsXqJR4pKdQR8u1JwEV7TlR1f5gMCrg==
@@ -5742,14 +5672,7 @@ minimatch@4.2.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1, minimatch@^5.1.0:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.2.tgz#0939d7d6f0898acbd1508abe534d1929368a8fff"
-  integrity sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^5.1.2:
+minimatch@^5.0.1, minimatch@^5.1.0, minimatch@^5.1.2:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==


### PR DESCRIPTION
### What does this PR do?
removes printing which api version is used per package per package.

now properly prints which api version is used per package, only once

BEFORE:
```
Pushing v55.0 metadata to [test-ovsqkpand1dp@example.com](mailto:test-ovsqkpand1dp@example.com) using the v56.0 SOAP API
DEPLOY PROGRESS | ████████████████████████████████████████ | 2/2 Components
Pushing v55.0 metadata to [test-ovsqkpand1dp@example.com](mailto:test-ovsqkpand1dp@example.com) using the v56.0 SOAP API
Pushing v55.0 metadata to [test-ovsqkpand1dp@example.com](mailto:test-ovsqkpand1dp@example.com) using the v56.0 SOAP API
DEPLOY PROGRESS | ████████████████████████████████████████ | 1/1 Components
Pushing v55.0 metadata to [test-ovsqkpand1dp@example.com](mailto:test-ovsqkpand1dp@example.com) using the v56.0 SOAP API
Pushing v55.0 metadata to [test-ovsqkpand1dp@example.com](mailto:test-ovsqkpand1dp@example.com) using the v56.0 SOAP API
Pushing v55.0 metadata to [test-ovsqkpand1dp@example.com](mailto:test-ovsqkpand1dp@example.com) using the v56.0 SOAP API
```

AFTER:
```
Pushing v55.0 metadata to [test-ovsqkpand1dp@example.com](mailto:test-ovsqkpand1dp@example.com) using the v56.0 SOAP API
DEPLOY PROGRESS | ████████████████████████████████████████ | 2/2 Components
Pushing v55.0 metadata to [test-ovsqkpand1dp@example.com](mailto:test-ovsqkpand1dp@example.com) using the v56.0 SOAP API
DEPLOY PROGRESS | ████████████████████████████████████████ | 1/1 Components
Pushing v55.0 metadata to [test-ovsqkpand1dp@example.com](mailto:test-ovsqkpand1dp@example.com) using the v56.0 SOAP API
DEPLOY PROGRESS | ████████████████████████████████████████ | 4/4 Components
```

### What issues does this PR fix or reference?
@W-12375309@ https://github.com/forcedotcom/cli/issues/1878