### PR TITLE
feat(adding experiencepropertytype bundle): support for ExperiencePropertyType Bundle 

### DIFF
--- a/src/formatters/source/pushResultFormatter.ts
+++ b/src/formatters/source/pushResultFormatter.ts
@@ -110,7 +110,12 @@ export class PushResultFormatter extends ResultFormatter {
       return withoutUnchanged;
     }
     const bundlesDeployed = withoutUnchanged.filter((fileResponse) =>
-      ['LightningComponentBundle', 'AuraDefinitionBundle', 'WaveTemplateBundle'].includes(fileResponse.type)
+      [
+        'LightningComponentBundle',
+        'AuraDefinitionBundle',
+        'WaveTemplateBundle',
+        'ExperiencePropertyTypeBundle',
+      ].includes(fileResponse.type)
     );
     if (bundlesDeployed.length === 0) {
       return withoutUnchanged;

--- a/test/commands/source/testConsts.ts
+++ b/test/commands/source/testConsts.ts
@@ -5,7 +5,9 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-export const exampleSourceComponent = {
+import { ComponentProperties } from '@salesforce/source-deploy-retrieve/lib/src/resolve/sourceComponent';
+
+export const exampleSourceComponent: ComponentProperties = {
   name: 'GeocodingService',
   type: {
     id: 'apexclass',


### PR DESCRIPTION
### What does this PR do?

With this PR we are adding a new metadata bundle ExperiencePropertyType. This bundle is very similar to waveTemplates. We don't have *meta.xml file, the bundles entirely contains JSON files.

### What issues does this PR fix or reference?
With this PR we are adding a new metadata bundle ExperiencePropertyType. [W-12502730]