### PR TITLE
fix: enhance partial bundle delete tests for forceignored files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@salesforce/command": "^5.2.35",
     "@salesforce/core": "^3.32.14",
     "@salesforce/kit": "^1.8.3",
-    "@salesforce/source-deploy-retrieve": "^7.9.0",
+    "@salesforce/source-deploy-retrieve": "^7.9.1",
     "@salesforce/source-tracking": "^2.2.21",
     "chalk": "^4.1.2",
     "got": "^11.8.3",

--- a/test/nuts/partialBundleDelete.nut.ts
+++ b/test/nuts/partialBundleDelete.nut.ts
@@ -62,7 +62,7 @@ describe('Partial Bundle Delete Retrieves', () => {
   //       has a DigitalBundleExperience. The test retrieves a changed DigitalExperience (forgotPassword)
   //       that doesn't contain a translation file (es.json). This should cause the local translation file
   //       to be deleted and reported as deleted by SDR and the source:retrieve command.
-  it('should replace and report local DEB content that was deleted for retrieve', async () => {
+  it.skip('should replace and report local DEB content that was deleted for retrieve', async () => {
     const forgotPasswordTranslationFile = path.join(
       projectPath,
       'digitalExperiences',

--- a/test/nuts/partialBundleDelete.nut.ts
+++ b/test/nuts/partialBundleDelete.nut.ts
@@ -62,7 +62,7 @@ describe('Partial Bundle Delete Retrieves', () => {
   //       has a DigitalBundleExperience. The test retrieves a changed DigitalExperience (forgotPassword)
   //       that doesn't contain a translation file (es.json). This should cause the local translation file
   //       to be deleted and reported as deleted by SDR and the source:retrieve command.
-  it.skip('should replace and report local DEB content that was deleted for retrieve', async () => {
+  it('should replace and report local DEB content that was deleted for retrieve', async () => {
     const forgotPasswordTranslationFile = path.join(
       projectPath,
       'digitalExperiences',
@@ -170,12 +170,14 @@ describe('Partial Bundle Delete Retrieves', () => {
     // delete the CSS file added to match the component in the org.
     it('should replace and report local LWC content that was deleted for retrieve', () => {
       const propertyTilePath = path.join(lwcSrcDir, 'propertyTile');
+      const testsDir = path.join(propertyTilePath, '__tests__');
 
       // Add another CSS file to the propertyTile component. This file
       // should be deleted after a retrieve of the component from the org.
       const testCssFile = path.join(propertyTilePath, 'testFile.css');
       fs.writeFileSync(testCssFile, '.THIS header { display: none; }');
       expect(fs.existsSync(testCssFile)).to.be.true;
+      expect(fs.existsSync(testsDir)).to.be.true;
 
       const result = execCmd<RetrieveCommandResult>(
         `force:source:retrieve -p ${propertyTilePath} -u ${scratchOrgUsername} --json`,
@@ -194,6 +196,7 @@ describe('Partial Bundle Delete Retrieves', () => {
         state: 'Deleted',
         filePath: testCssFile,
       });
+      expect(fs.existsSync(testsDir)).to.be.true;
     });
 
     // This test uses the dreamhouse-lwc repo and retrieves an LWC that has local

--- a/yarn.lock
+++ b/yarn.lock
@@ -1285,10 +1285,10 @@
     chalk "^4"
     inquirer "^8.2.5"
 
-"@salesforce/source-deploy-retrieve@^7.7.5", "@salesforce/source-deploy-retrieve@^7.8.0", "@salesforce/source-deploy-retrieve@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.9.0.tgz#4e9499d908f3877bb5cd9704598b07398976c81f"
-  integrity sha512-khGd4vBwZWDBnM6ZqddCdPnLMrZ5UXfv/3xZK6MvslPHo/qo9KoagYWZFzCQV0fyMW9XmYgGuJHi0SpG2KjQ8w==
+"@salesforce/source-deploy-retrieve@^7.7.5", "@salesforce/source-deploy-retrieve@^7.8.0", "@salesforce/source-deploy-retrieve@^7.9.1":
+  version "7.9.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-7.9.1.tgz#25567787a95528f45a5a2306c1b087dd67a316e4"
+  integrity sha512-sWQmW35irfEYqFlc6kCo+pRimN9X5d+cCnOJ5zTRWvALcCDce5j/OhPb8qPVMWV4sciHO+RbdMYHJAMppOXrJg==
   dependencies:
     "@salesforce/core" "^3.33.1"
     "@salesforce/kit" "^1.8.4"


### PR DESCRIPTION
### What does this PR do?
Modifies existing NUTs to ensure forceignored files are not deleted during a partial bundle delete retrieve.

### What issues does this PR fix or reference?
@W-12460543@