### PR TITLE
Sm/strict-mode-for-sdr

### DIFF
--- a/src/commands/force/source/retrieve.ts
+++ b/src/commands/force/source/retrieve.ts
@@ -17,6 +17,7 @@ import {
   RequestStatus,
   RetrieveVersionData,
   RetrieveResult,
+  RegistryAccess,
 } from '@salesforce/source-deploy-retrieve';
 import { SourceTracking } from '@salesforce/source-tracking';
 import { SourceCommand } from '../../../sourceCommand';
@@ -96,6 +97,7 @@ export class Retrieve extends SourceCommand {
   protected retrieveResult: RetrieveResult;
   protected tracking: SourceTracking;
   private resolvedTargetDir: string;
+  private registry = new RegistryAccess();
 
   public async run(): Promise<RetrieveCommandResult> {
     await this.preChecks();
@@ -161,7 +163,10 @@ export class Retrieve extends SourceCommand {
     if (this.getFlag<string>('manifest') || this.getFlag<string>('metadata')) {
       if (this.wantsToRetrieveCustomFields()) {
         this.ux.warn(messages.getMessage('wantsToRetrieveCustomFields'));
-        this.componentSet.add({ fullName: ComponentSet.WILDCARD, type: { id: 'customobject', name: 'CustomObject' } });
+        this.componentSet.add({
+          fullName: ComponentSet.WILDCARD,
+          type: this.registry.getTypeByName('CustomObject'),
+        });
       }
     }
     if (this.getFlag<boolean>('tracksource')) {
@@ -241,12 +246,12 @@ export class Retrieve extends SourceCommand {
 
   private wantsToRetrieveCustomFields(): boolean {
     const hasCustomField = this.componentSet.has({
-      type: { name: 'CustomField', id: 'customfield' },
+      type: this.registry.getTypeByName('CustomField'),
       fullName: ComponentSet.WILDCARD,
     });
 
     const hasCustomObject = this.componentSet.has({
-      type: { name: 'CustomObject', id: 'customobject' },
+      type: this.registry.getTypeByName('CustomObject'),
       fullName: ComponentSet.WILDCARD,
     });
     return hasCustomField && !hasCustomObject;

--- a/test/commands/source/delete.test.ts
+++ b/test/commands/source/delete.test.ts
@@ -14,6 +14,7 @@ import {
   ComponentSetBuilder,
   ComponentSetOptions,
   SourceComponent,
+  RegistryAccess,
 } from '@salesforce/source-deploy-retrieve';
 import { Lifecycle, Org, SfProject } from '@salesforce/core';
 import { fromStub, stubInterface, stubMethod } from '@salesforce/ts-sinon';
@@ -23,6 +24,7 @@ import { Delete } from '../../../src/commands/force/source/delete';
 import { exampleDeleteResponse, exampleSourceComponent } from './testConsts';
 
 const fsPromises = fs.promises;
+const registry = new RegistryAccess();
 
 describe('force:source:delete', () => {
   const sandbox = sinon.createSandbox();
@@ -186,13 +188,7 @@ describe('force:source:delete', () => {
     buildComponentSetStub.restore();
     const comp = new SourceComponent({
       name: 'mylwc',
-      type: {
-        id: 'lightningcomponentbundle',
-        name: 'LightningComponentBundle',
-        strategies: {
-          adapter: 'bundle',
-        },
-      },
+      type: registry.getTypeByName('LightningComponentBundle'),
     });
     stubMethod(sandbox, ComponentSetBuilder, 'build').resolves({
       toArray: () => [comp],

--- a/test/commands/source/retrieve.test.ts
+++ b/test/commands/source/retrieve.test.ts
@@ -315,7 +315,7 @@ describe('force:source:retrieve', () => {
         expect(component)
           .to.be.a('object')
           .and.to.have.property('type')
-          .and.to.deep.equal({ id: 'customobject', name: 'CustomObject' });
+          .and.to.deep.include({ id: 'customobject', name: 'CustomObject' });
         expect(component).and.to.have.property('fullName').and.to.be.equal(ComponentSet.WILDCARD);
       },
       has: (component: ComponentLike) => {
@@ -376,7 +376,7 @@ describe('force:source:retrieve', () => {
         expect(component)
           .to.be.a('object')
           .and.to.have.property('type')
-          .and.to.deep.equal({ id: 'customobject', name: 'CustomObject' });
+          .and.to.deep.include({ id: 'customobject', name: 'CustomObject' });
         expect(component).and.to.have.property('fullName').and.to.be.equal(ComponentSet.WILDCARD);
       },
       has: (component: ComponentLike) => {


### PR DESCRIPTION
### What does this PR do?
prepare for sdr moving to strict mode

SDR had the `directoryName` property in the registry as optional.

When making it required, consumers who were constructing types manually with minimal information would be broken.

The better, less brittle approach if you need an SDR type it to get it from the registry

### What issues does this PR fix or reference?

@W-12671663@
see https://github.com/forcedotcom/source-deploy-retrieve/actions/runs/4385912070/jobs/7679491096