### PR TITLE
feat: verbose deploys without progress bar update with each poll

### DIFF
--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -243,7 +243,7 @@ export class Deploy extends DeployCommand {
         if (!this.isJsonOutput()) {
           const progressFormatter: ProgressFormatter = env.getBoolean('SFDX_USE_PROGRESS_BAR', true)
             ? new DeployProgressBarFormatter(this.logger, this.ux)
-            : new DeployProgressStatusFormatter(this.logger, this.ux);
+            : new DeployProgressStatusFormatter(this.logger, this.ux, { verbose: this.getFlag<boolean>('verbose') });
           progressFormatter.progress(deploy);
         }
         this.deployResult = await deploy.pollStatus({ timeout: waitDuration });

--- a/src/formatters/deployProgressStatusFormatter.ts
+++ b/src/formatters/deployProgressStatusFormatter.ts
@@ -11,18 +11,26 @@ import { getNumber } from '@salesforce/ts-types';
 import { MetadataApiDeploy, MetadataApiDeployStatus } from '@salesforce/source-deploy-retrieve';
 import { Duration } from '@salesforce/kit';
 import { ProgressFormatter } from './progressFormatter';
+import { ResultFormatterOptions } from './resultFormatter';
 export class DeployProgressStatusFormatter extends ProgressFormatter {
   private previousComponents = -1;
   private previousTests = -1;
-  public constructor(logger: Logger, ux: UX) {
+  public constructor(logger: Logger, ux: UX, private options?: Pick<ResultFormatterOptions, 'verbose'>) {
     super(logger, ux);
   }
 
   // This can be used to print the progress of the deployment.
   public progress(deploy: MetadataApiDeploy): void {
     deploy.onUpdate((data) => {
-      // Printing status only when number of components or tests gets changed in progress.
-      if (data.numberComponentsDeployed > this.previousComponents || data.numberTestsCompleted > this.previousTests) {
+      // Print status when:
+      //   1. Number of deployed components increases
+      //   2. Number of tests completed increases
+      //   3. Command is running in verbose mode (for updates on each poll)
+      if (
+        data.numberComponentsDeployed > this.previousComponents ||
+        data.numberTestsCompleted > this.previousTests ||
+        this.options?.verbose
+      ) {
         this.printDeployStatus(data);
         this.previousComponents = data.numberComponentsDeployed;
         this.previousTests = data.numberTestsCompleted;

--- a/test/formatters/deployProgressStatusFormatter.ts
+++ b/test/formatters/deployProgressStatusFormatter.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { Logger } from '@salesforce/core';
+import { UX } from '@salesforce/command';
+import { MetadataApiDeploy } from '@salesforce/source-deploy-retrieve';
+import { getDeployResult } from '../commands/source/deployResponses';
+import { DeployProgressStatusFormatter } from '../../src/formatters/deployProgressStatusFormatter';
+
+describe('DeployProgressStatusFormatter', () => {
+  const sandbox = sinon.createSandbox();
+  const deployResultInProgress = getDeployResult('inProgress');
+  const logger = Logger.childFromRoot('deployTestLogger').useMemoryLogging();
+  let ux;
+  let printStub: sinon.SinonStub;
+  let mdApiDeploy: MetadataApiDeploy;
+
+  beforeEach(() => {
+    mdApiDeploy = new MetadataApiDeploy({ usernameOrConnection: 'test' });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore  stubbing private method
+    printStub = sandbox.stub(DeployProgressStatusFormatter.prototype, 'printDeployStatus');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const fireUpdateEvent = () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore eslint-disable-next-line
+    mdApiDeploy.event.emit('update', deployResultInProgress.response); // eslint-disable-line
+  };
+
+  it('should output with every update when verbose', async () => {
+    const formatter = new DeployProgressStatusFormatter(logger, ux as UX, { verbose: true });
+    formatter.progress(mdApiDeploy);
+
+    fireUpdateEvent();
+    expect(printStub.calledOnce).to.equal(true);
+
+    fireUpdateEvent();
+    expect(printStub.calledTwice).to.equal(true);
+
+    fireUpdateEvent();
+    expect(printStub.calledThrice).to.equal(true);
+  });
+
+  it('should only output on update when results change without verbose', async () => {
+    const formatter = new DeployProgressStatusFormatter(logger, ux as UX);
+    formatter.progress(mdApiDeploy);
+
+    fireUpdateEvent();
+    expect(printStub.calledOnce).to.equal(true);
+
+    fireUpdateEvent();
+    expect(printStub.calledOnce).to.equal(true);
+
+    // Now change the deploy results
+    deployResultInProgress.response.numberComponentsDeployed++;
+
+    fireUpdateEvent();
+    expect(printStub.calledTwice).to.equal(true);
+  });
+});


### PR DESCRIPTION
### What does this PR do?
When the `force:source:deploy` command is run with the `--verbose` flag and the progress bar is turned off with `SFDX_USE_PROGRESS_BAR=false` the deploy status is output with every poll.  With this change, CI systems that have low output timeouts will not exit for long-running deploys, where the command does not output for many minutes.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/1839
@W-12234469@