### PR TITLE
fix: change deprecation messages to avoid undefined command id

### DIFF
--- a/messages/cancel.md
+++ b/messages/cancel.md
@@ -36,4 +36,4 @@ The cancel command failed due to: %s
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/deploy.md
+++ b/messages/deploy.md
@@ -262,4 +262,4 @@ You requested an async deploy with code coverage or JUnit results. The reports w
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/ignored_list.md
+++ b/messages/ignored_list.md
@@ -18,4 +18,4 @@ File or directory '%s' doesn't exist in your project. Specify one that exists an
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/md.cancel.md
+++ b/messages/md.cancel.md
@@ -43,4 +43,4 @@ The cancel command failed due to: %s
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/md.deploy.md
+++ b/messages/md.deploy.md
@@ -198,4 +198,4 @@ You requested an async deploy with code coverage or JUnit results. The reports w
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/md.deployreport.md
+++ b/messages/md.deployreport.md
@@ -62,4 +62,4 @@ Using specified username %s
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/md.retrieve.md
+++ b/messages/md.retrieve.md
@@ -143,4 +143,4 @@ If the retrieve request has completed, the retrieved metadata zip file will be w
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/pull.md
+++ b/messages/pull.md
@@ -56,4 +56,4 @@ Your retrieve request did not complete within the specified wait time [%s minute
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/push.md
+++ b/messages/push.md
@@ -52,4 +52,4 @@ Check the order of your dependencies and ensure all metadata is included.
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/report.md
+++ b/messages/report.md
@@ -59,4 +59,4 @@ The metadata deploy operation failed.
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/retrieve.md
+++ b/messages/retrieve.md
@@ -186,4 +186,4 @@ The retrieve target directory [%s] overlaps one of your package directories. Spe
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.

--- a/messages/status.md
+++ b/messages/status.md
@@ -54,4 +54,4 @@ No local or remote changes found.
 
 # deprecation
 
-The '<%= command.id %>' command will be deprecated. Try using the %s command instead.
+This command will be deprecated. Try using the '%s' command instead.


### PR DESCRIPTION
### What does this PR do?
fixes 
`Warning: The '<%= command.id %>' command will be deprecated. Try using the project deploy start command instead.`

to 

`Warning: This command will be deprecated. Try using the 'project deploy start' command instead.`

### What issues does this PR fix or reference?
[skip-validate-pr]