### PR TITLE
Remove nuts:delete script

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "prepare": "sf-install",
     "test": "wireit",
     "test:nuts": "ts-node ./test/nuts/generateNuts.ts && nyc mocha \"**/*.nut.ts\"  --slow 4500 --timeout 1200000 --parallel --retries 0",
-    "test:nuts:delete": "mocha \"test/nuts/delete.nut.ts\" --slow 4500 --timeout 1200000 --retries 0 --jobs 20",
     "test:nuts:deploy": "cross-env PLUGIN_SOURCE_SEED_FILTER=deploy PLUGIN_SOURCE_SEED_EXCLUDE=async ts-node ./test/nuts/generateNuts.ts && mocha \"test/nuts/generated/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --retries 0 --jobs 20",
     "test:nuts:deploy:async": "cross-env PLUGIN_SOURCE_SEED_FILTER=deploy.async ts-node ./test/nuts/generateNuts.ts && mocha \"test/nuts/generated/*.nut.ts\" --slow 4500 --timeout 1200000 --parallel --retries 0 --jobs 20",
     "test:nuts:deploy:destructive": "mocha \"test/nuts/deployDestructive.nut.ts\" --slow 3000 --timeout 1200000 --retries 0 --jobs 20",


### PR DESCRIPTION
### What does this PR do?
Removes a yarn script that calls a nut that migrated to `plugin-deploy-retrieve`

### What issues does this PR fix or reference?
[skip-validate-pr]