### PR TITLE
feat: remove STL compatibility features for old toolbelt tracking files

### DIFF
--- a/src/commands/force/source/deploy.ts
+++ b/src/commands/force/source/deploy.ts
@@ -170,7 +170,6 @@ export class Deploy extends DeployCommand {
   protected async preChecks(): Promise<void> {
     if (this.flags.tracksource) {
       this.tracking = await trackingSetup({
-        commandName: 'force:source:deploy',
         // we'll check ACTUAL conflicts once we get a componentSet built
         ignoreConflicts: true,
         org: this.org,

--- a/src/commands/force/source/pull.ts
+++ b/src/commands/force/source/pull.ts
@@ -85,7 +85,6 @@ export default class Pull extends SourceCommand {
   protected async preChecks(): Promise<void> {
     this.spinner.start('Loading source tracking information');
     this.tracking = await trackingSetup({
-      commandName: 'force:source:pull',
       ignoreConflicts: this.flags.forceoverwrite ?? false,
       org: this.flags['target-org'],
       project: this.project,

--- a/src/commands/force/source/push.ts
+++ b/src/commands/force/source/push.ts
@@ -84,7 +84,6 @@ export default class Push extends DeployCommand {
 
   protected async prechecks(): Promise<void> {
     this.tracking = await trackingSetup({
-      commandName: 'force:source:push',
       ignoreConflicts: this.flags.forceoverwrite ?? false,
       org: this.flags['target-org'],
       project: this.project,

--- a/src/commands/force/source/retrieve.ts
+++ b/src/commands/force/source/retrieve.ts
@@ -148,7 +148,6 @@ export class Retrieve extends SourceCommand {
         org: this.flags['target-org'],
         project: this.project,
         ignoreConflicts: true,
-        commandName: 'force:source:retrieve',
       });
     }
   }

--- a/src/commands/force/source/status.ts
+++ b/src/commands/force/source/status.ts
@@ -59,7 +59,6 @@ export default class Status extends SfCommand<StatusCommandResult> {
   public async run(): Promise<StatusCommandResult> {
     this.flags = (await this.parse(Status)).flags;
     const tracking = await trackingSetup({
-      commandName: 'force:source:status',
       ignoreConflicts: true,
       org: this.flags['target-org'],
       project: this.project,

--- a/src/sourceCommand.ts
+++ b/src/sourceCommand.ts
@@ -17,10 +17,6 @@ import { EnsureFsFlagOptions, FsError, ProgressBar } from './types';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-source', 'flags.validation');
 
-// TODO: use messages for tracking version compatibility errors
-// Messages.importMessagesDirectory(__dirname);
-// const messages = Messages.loadMessages('@salesforce/plugin-source', 'retrieve');
-
 export abstract class SourceCommand extends SfCommand<unknown> {
   public static readonly DEFAULT_WAIT_MINUTES = 33;
 

--- a/src/trackingFunctions.ts
+++ b/src/trackingFunctions.ts
@@ -6,13 +6,7 @@
  */
 import * as path from 'path';
 
-import {
-  ChangeResult,
-  getTrackingFileVersion,
-  SourceTracking,
-  SourceTrackingOptions,
-  throwIfInvalid,
-} from '@salesforce/source-tracking';
+import { ChangeResult, SourceTracking, SourceTrackingOptions } from '@salesforce/source-tracking';
 import { Messages, SfError } from '@salesforce/core';
 import {
   ComponentSet,
@@ -28,7 +22,6 @@ const messages = Messages.loadMessages('@salesforce/plugin-source', 'tracking');
 interface TrackingSetupRequest extends SourceTrackingOptions {
   ignoreConflicts: boolean;
   ux: Ux;
-  commandName: string;
 }
 
 interface TrackingUpdateRequest {
@@ -75,29 +68,7 @@ export const filterConflictsByComponentSet = async ({
  * @returns SourceTracking
  */
 export const trackingSetup = async (options: TrackingSetupRequest): Promise<SourceTracking> => {
-  const { ux, org, ignoreConflicts, commandName, ...createOptions } = options;
-  const projectPath = options.project.getPath();
-  // 3 commands use throwIfInvalid
-  if (commandName.endsWith('push') || commandName.endsWith('pull') || commandName.endsWith('status')) {
-    throwIfInvalid({
-      org,
-      projectPath,
-      toValidate: 'plugin-source',
-      command: commandName,
-    });
-  }
-  // confirm tracking file version is plugin-source for all --tracksource flags (deploy, retrieve, delete)
-  if (getTrackingFileVersion(org, projectPath) === 'toolbelt') {
-    throw new SfError(
-      'You cannot use the "tracksource" flag with the old version of the tracking files',
-      'sourceTrackingFileVersionMismatch',
-      [
-        'Clear the old version of the tracking files with "sfdx force:source:legacy:tracking:clear"',
-        'Create a new org to use the new tracking files',
-      ]
-    );
-  }
-
+  const { ux, org, ignoreConflicts, ...createOptions } = options;
   const tracking = await SourceTracking.create({ org, ...createOptions });
   if (!ignoreConflicts) {
     processConflicts(await tracking.getConflicts(), ux, messages.getMessage('conflictMsg'));


### PR DESCRIPTION
### What does this PR do?
while we still had toolbelt around, these commands would use STL's compatibility code to check which version of tracking fils were present, to give users helpful messages about how not to mix old and new local tracking files.

This takes all of that out

### What issues does this PR fix or reference?
@W-12293678@