### PR TITLE
fix: default for wait on mdapi:report commands

### DIFF
--- a/messages/md.deployreport.md
+++ b/messages/md.deployreport.md
@@ -54,4 +54,4 @@ Using specified username %s.
 
 # deprecation
 
-We plan to deprecate this command in the future. Try using the "%s" command instead.
+We plan to deprecate this command in the future. Try using the "%s" and "%s" pair instead.

--- a/messages/report.md
+++ b/messages/report.md
@@ -50,4 +50,4 @@ The metadata deploy operation failed.
 
 # deprecation
 
-We plan to deprecate this command in the future. Try using the "%s" command instead.
+We plan to deprecate this command in the future. Try using the "%s" and "%s" pair instead.

--- a/src/commands/force/mdapi/deploy/report.ts
+++ b/src/commands/force/mdapi/deploy/report.ts
@@ -43,6 +43,7 @@ export class Report extends DeployCommand {
     wait: Flags.duration({
       char: 'w',
       defaultValue: 0,
+      default: Duration.minutes(0),
       min: -1,
       unit: 'minutes',
       summary: messages.getMessage('flags.wait.summary'),
@@ -88,7 +89,7 @@ export class Report extends DeployCommand {
       this.log(messages.getMessage('usernameOutput', [this.org.getUsername()]));
     }
     const waitFlag = this.flags.wait;
-    const waitDuration = waitFlag.minutes === -1 ? Duration.days(7) : waitFlag;
+    const waitDuration = waitFlag?.minutes === -1 ? Duration.days(7) : waitFlag;
 
     this.isAsync = waitDuration.quantity === 0;
 

--- a/src/commands/force/mdapi/deploy/report.ts
+++ b/src/commands/force/mdapi/deploy/report.ts
@@ -34,7 +34,7 @@ export class Report extends DeployCommand {
   public static readonly state = 'deprecated';
   public static readonly deprecationOptions = {
     to: replacement,
-    message: messages.getMessage('deprecation', [replacement]),
+    message: messages.getMessage('deprecation', ['project deploy start', replacement]),
   };
   public static readonly flags = {
     'api-version': orgApiVersionFlagWithDeprecations,

--- a/src/commands/force/mdapi/retrieve/report.ts
+++ b/src/commands/force/mdapi/retrieve/report.ts
@@ -60,6 +60,7 @@ export class Report extends SourceCommand {
       unit: 'minutes',
       summary: messages.getMessage('flags.wait.summary'),
       min: -1,
+      default: Duration.minutes(1440),
       defaultValue: 1440, // 24 hours is a reasonable default versus -1 (no timeout)
     }),
     verbose: Flags.boolean({

--- a/src/commands/force/source/deploy/report.ts
+++ b/src/commands/force/source/deploy/report.ts
@@ -40,7 +40,7 @@ export class Report extends DeployCommand {
   public static readonly state = 'deprecated';
   public static readonly deprecationOptions = {
     to: replacement,
-    message: messages.getMessage('deprecation', [replacement]),
+    message: messages.getMessage('deprecation', ['project deploy start', replacement]),
   };
   public static readonly flags = {
     'api-version': orgApiVersionFlagWithDeprecations,


### PR DESCRIPTION
### What does this PR do?
sets a default on the `wait` flag on both mdapi report commands.

### What issues does this PR fix or reference?
[@W-12992146@](https://github.com/forcedotcom/cli/issues/2042)
