### PR TITLE
fix: update retrieve test to use new test setup features

### DIFF
--- a/test/commands/source/retrieve.test.ts
+++ b/test/commands/source/retrieve.test.ts
@@ -29,7 +29,7 @@ import { exampleSourceComponent } from './testConsts';
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-source', 'retrieve');
 
-describe.only('force:source:retrieve', () => {
+describe('force:source:retrieve', () => {
   const $$ = new TestContext();
   const testOrg = new MockTestOrgData();
   let sfCommandUxStubs: ReturnType<typeof stubSfCommandUx>;


### PR DESCRIPTION
### What does this PR do?
updates retrieve.test.ts to use new TestSetup features from sfdx-core

### What issues does this PR fix or reference?
[skip-validate-pr]