### PR TITLE
test: api version on projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@oclif/plugin-command-snapshot": "^4.0.9",
     "@oclif/plugin-help": "^5.2.11",
-    "@salesforce/cli-plugins-testkit": "^4.2.9",
+    "@salesforce/cli-plugins-testkit": "^4.3.0",
     "@salesforce/dev-config": "^4.0.1",
     "@salesforce/dev-scripts": "^5.7.0",
     "@salesforce/plugin-command-reference": "^3.0.25",

--- a/test/nuts/mdapi.nut.ts
+++ b/test/nuts/mdapi.nut.ts
@@ -25,6 +25,7 @@ describe('1k files in mdapi:deploy', () => {
     session = await TestSession.create({
       project: {
         name: 'large-repo',
+        apiVersion: '58.0',
       },
       devhubAuthStrategy: 'AUTO',
       scratchOrgs: [

--- a/test/nuts/trackingCommands/forceIgnore.nut.ts
+++ b/test/nuts/trackingCommands/forceIgnore.nut.ts
@@ -31,6 +31,7 @@ describe('forceignore changes', () => {
     session = await TestSession.create({
       project: {
         name: 'forceIgnoreTest',
+        apiVersion: '58.0',
       },
       devhubAuthStrategy: 'AUTO',
       scratchOrgs: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -960,14 +960,14 @@
     istanbul-lib-report "^3.0.1"
     istanbul-reports "^3.1.6"
 
-"@salesforce/cli-plugins-testkit@^4.2.9":
-  version "4.2.9"
-  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.2.9.tgz#813bbb6a7926d17d5d0becd664e08f1c115680d1"
-  integrity sha512-v71dFmhlgwtmehK2QJ8+toeCYc39WQFu7R2wmhsHQeVA1UuYcx3uue5JnC392PIXddxQtjdR6eazk52tQg4nyA==
+"@salesforce/cli-plugins-testkit@^4.2.9", "@salesforce/cli-plugins-testkit@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/cli-plugins-testkit/-/cli-plugins-testkit-4.3.0.tgz#253079d476569fbc4977c8100b3bf201b3e4a788"
+  integrity sha512-kW59i4muO49evQ76waWTfDUXpTfyBUQ0N1QIF4ZFB+aSAdVGG5N/oTMYz882ScS/SwB0XP0H119wT4cLoJI+Mw==
   dependencies:
     "@salesforce/core" "^5.2.0"
     "@salesforce/kit" "^3.0.9"
-    "@salesforce/ts-types" "^2.0.2"
+    "@salesforce/ts-types" "^2.0.6"
     "@types/shelljs" "^0.8.12"
     debug "^4.3.1"
     jszip "^3.10.1"
@@ -1228,7 +1228,7 @@
     sinon "^5.1.1"
     tslib "^2.5.3"
 
-"@salesforce/ts-types@^2.0.1", "@salesforce/ts-types@^2.0.2", "@salesforce/ts-types@^2.0.5", "@salesforce/ts-types@^2.0.6":
+"@salesforce/ts-types@^2.0.1", "@salesforce/ts-types@^2.0.5", "@salesforce/ts-types@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-2.0.6.tgz#659590ee6ece45213bbdb23c9e244d206a2f912e"
   integrity sha512-hGSU3pwZKItAw567cD2hf+nwe4yPVANonb1E28bLVaRjYAI6FmdxjjTxA+wZRrTpTCpjd5TY67Lq2X1X1lY8bA==


### PR DESCRIPTION
> requires https://github.com/salesforcecli/cli-plugins-testkit/pull/539

### What does this PR do?
templates goes to v59, but the org might not support it for a few weeks.

This sets the api version on the created classes and the testkit project sourceApiVersion

### What issues does this PR fix or reference?
[@W-13913391@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001XvsAqYAJ/view)
kinda caused by our rollout of [@W-13586057@](https://gus.lightning.force.com/a07EE00001Tl80JYAR)
example of the problem this solves: https://github.com/salesforcecli/cli/actions/runs/5804183268/job/15734000727