### PR TITLE
Sm/no-json-in-table

### DIFF
--- a/src/formatters/codeCoverageTable.ts
+++ b/src/formatters/codeCoverageTable.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { ensureArray } from '@salesforce/kit';
+import { Ux } from '@salesforce/sf-plugins-core';
+import { CodeCoverage } from '@salesforce/source-deploy-retrieve';
+import chalk = require('chalk');
+import { prepCoverageForDisplay } from '../coverageUtils';
+
+/**
+ * prints a table of formatted code coverage results if there are any
+ * This is a no-op if tests didn't run or there is no coverage
+ *
+ * @param coverageFromMdapiResult
+ * @param ux
+ */
+export const maybePrintCodeCoverageTable = (coverageFromMdapiResult: CodeCoverage | CodeCoverage[], ux: Ux): void => {
+  const codeCoverage = ensureArray(coverageFromMdapiResult);
+
+  if (codeCoverage.length) {
+    const coverage = prepCoverageForDisplay(codeCoverage);
+
+    ux.log('');
+    ux.styledHeader(chalk.blue('Apex Code Coverage'));
+
+    ux.table(
+      coverage.map((entry) => ({
+        name: entry.name,
+        numLocations: entry.numLocations,
+        lineNotCovered: entry.lineNotCovered,
+      })),
+      {
+        name: { header: 'Name' },
+        numLocations: { header: '% Covered' },
+        lineNotCovered: { header: 'Uncovered Lines' },
+      }
+    );
+  }
+};

--- a/src/formatters/deployResultFormatter.ts
+++ b/src/formatters/deployResultFormatter.ts
@@ -315,7 +315,7 @@ export class DeployResultFormatter extends ResultFormatter {
         coverage.map((cov) => ({
           name: cov.name,
           numLocations: cov.numLocations,
-          lineNotCovered: cov.locationsNotCovered,
+          lineNotCovered: cov.lineNotCovered,
         })),
         {
           name: { header: 'Name' },

--- a/src/formatters/deployResultFormatter.ts
+++ b/src/formatters/deployResultFormatter.ts
@@ -22,9 +22,9 @@ import {
   Successes,
 } from '@salesforce/source-deploy-retrieve';
 import { Ux } from '@salesforce/sf-plugins-core';
-import { prepCoverageForDisplay } from '../coverageUtils';
 import { ResultFormatter, ResultFormatterOptions } from './resultFormatter';
 import { MdDeployResult } from './mdapi/mdDeployResultFormatter';
+import { maybePrintCodeCoverageTable } from './codeCoverageTable';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-source', 'deploy');
@@ -304,26 +304,7 @@ export class DeployResultFormatter extends ResultFormatter {
         }
       );
     }
-    const codeCoverage = ensureArray(this.result?.response?.details?.runTestResult?.codeCoverage);
-
-    if (codeCoverage.length) {
-      const coverage = prepCoverageForDisplay(codeCoverage);
-
-      this.ux.log('');
-      this.ux.styledHeader(chalk.blue('Apex Code Coverage'));
-      this.ux.table(
-        coverage.map((cov) => ({
-          name: cov.name,
-          numLocations: cov.numLocations,
-          lineNotCovered: cov.lineNotCovered,
-        })),
-        {
-          name: { header: 'Name' },
-          numLocations: { header: '% Covered' },
-          lineNotCovered: { header: 'Uncovered Lines' },
-        }
-      );
-    }
+    maybePrintCodeCoverageTable(this.result.response.details?.runTestResult?.codeCoverage, this.ux);
   }
 
   protected verboseTestTime(): void {

--- a/src/formatters/mdapi/mdDeployResultFormatter.ts
+++ b/src/formatters/mdapi/mdDeployResultFormatter.ts
@@ -19,7 +19,7 @@ import {
 import { ensureArray } from '@salesforce/kit';
 import { Ux } from '@salesforce/sf-plugins-core';
 import { CoverageResultsFileInfo, ResultFormatter, ResultFormatterOptions } from '../resultFormatter';
-import { prepCoverageForDisplay } from '../../coverageUtils';
+import { maybePrintCodeCoverageTable } from '../codeCoverageTable';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-source', 'md.deploy');
@@ -212,27 +212,7 @@ export class MdDeployResultFormatter extends ResultFormatter {
         }
       );
     }
-    const codeCoverage = ensureArray(this.result?.response?.details?.runTestResult?.codeCoverage);
-
-    if (codeCoverage.length) {
-      const coverage = prepCoverageForDisplay(codeCoverage);
-
-      this.ux.log('');
-      this.ux.styledHeader(chalk.blue('Apex Code Coverage'));
-
-      this.ux.table(
-        coverage.map((entry) => ({
-          name: entry.name,
-          numLocations: entry.numLocations,
-          lineNotCovered: entry.lineNotCovered,
-        })),
-        {
-          name: { header: 'Name' },
-          numLocations: { header: '% Covered' },
-          lineNotCovered: { header: 'Uncovered Lines' },
-        }
-      );
-    }
+    maybePrintCodeCoverageTable(this.result.response.details?.runTestResult?.codeCoverage, this.ux);
   }
 
   protected verboseTestTime(): void {

--- a/src/formatters/mdapi/mdDeployResultFormatter.ts
+++ b/src/formatters/mdapi/mdDeployResultFormatter.ts
@@ -220,12 +220,11 @@ export class MdDeployResultFormatter extends ResultFormatter {
       this.ux.log('');
       this.ux.styledHeader(chalk.blue('Apex Code Coverage'));
 
-      // TODO: unsure about locationsNotCovered vs lineNotCovered
       this.ux.table(
         coverage.map((entry) => ({
           name: entry.name,
           numLocations: entry.numLocations,
-          lineNotCovered: entry.locationsNotCovered,
+          lineNotCovered: entry.lineNotCovered,
         })),
         {
           name: { header: 'Name' },

--- a/test/coverageUtils.test.ts
+++ b/test/coverageUtils.test.ts
@@ -372,4 +372,17 @@ describe('transform md RunTestResult', () => {
     expect(codeCoverage[4].numLocations).to.equal(chalk.green('90%'));
     expect(codeCoverage[5].numLocations).to.equal(chalk.green('100%'));
   });
+
+  it('lineNotCovered is empty string when there is no data', () => {
+    const codeCoverage = prepCoverageForDisplay(sampleTestResult.codeCoverage);
+    expect(codeCoverage.find((c) => c.name === 'SampleDataController').lineNotCovered).equal('');
+  });
+  it('lineNotCovered is single number for one item', () => {
+    const codeCoverage = prepCoverageForDisplay(sampleTestResult.codeCoverage);
+    expect(codeCoverage.find((c) => c.name === 'PagedResult').lineNotCovered).equal('12');
+  });
+  it('lineNotCovered is comma separated list for multiple items', () => {
+    const codeCoverage = prepCoverageForDisplay(sampleTestResult.codeCoverage);
+    expect(codeCoverage.find((c) => c.name === 'PropertyController').lineNotCovered).equal('26,31,78');
+  });
 });


### PR DESCRIPTION
### What does this PR do?
1. use the correct property from the coverage results
2. pull in color enhancements from https://github.com/salesforcecli/plugin-source/pull/934/
3. share 1 coverage table between both mdapi and source result formatters
4. improve UT coverage of the human output generation function

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2468
@W-14123241@