### PR TITLE
test: remove error name assertions (let SDR handle)

### DIFF
--- a/test/nuts/seeds/deploy.metadata.seed.ts
+++ b/test/nuts/seeds/deploy.metadata.seed.ts
@@ -51,8 +51,7 @@ context('Deploy metadata NUTs [name: %REPO_NAME%]', () => {
     }
 
     it('should throw an error if the metadata is not valid', async () => {
-      const deploy = await testkit.deploy({ args: '--metadata DOES_NOT_EXIST', exitCode: 1 });
-      testkit.expect.errorToHaveName(deploy ?? {}, 'SfError');
+      await testkit.deploy({ args: '--metadata DOES_NOT_EXIST', exitCode: 1 });
     });
 
     it('should not deploy metadata outside of a package directory', async () => {

--- a/test/nuts/seeds/retrieve.metadata.seed.ts
+++ b/test/nuts/seeds/retrieve.metadata.seed.ts
@@ -8,7 +8,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { SourceTestkit } from '@salesforce/source-testkit';
-import { JsonMap } from '@salesforce/ts-types';
 import { RepoConfig, TEST_REPOS_MAP } from '../testMatrix.js';
 
 // DO NOT TOUCH. generateNuts.ts will insert these values
@@ -70,8 +69,7 @@ context('Retrieve metadata NUTs [name: %REPO_NAME%]', () => {
     }
 
     it('should throw an error if the metadata is not valid', async () => {
-      const retrieve = (await testkit.retrieve({ args: '--metadata DOES_NOT_EXIST', exitCode: 1 })) as JsonMap;
-      testkit.expect.errorToHaveName(retrieve, 'SfError');
+      await testkit.retrieve({ args: '--metadata DOES_NOT_EXIST', exitCode: 1 });
     });
   });
 });

--- a/test/nuts/seeds/retrieve.retrievetargetdir.seed.ts
+++ b/test/nuts/seeds/retrieve.retrievetargetdir.seed.ts
@@ -7,7 +7,6 @@
 
 import { fileURLToPath } from 'node:url';
 import { SourceTestkit } from '@salesforce/source-testkit';
-import { JsonMap } from '@salesforce/ts-types';
 import { RepoConfig, TEST_REPOS_MAP } from '../testMatrix.js';
 
 // DO NOT TOUCH. generateNuts.ts will insert these values
@@ -45,11 +44,10 @@ context('Retrieve metadata NUTs [name: %REPO_NAME%]', () => {
     }
 
     it('should throw an error if the metadata is not valid', async () => {
-      const retrieve = (await testkit.retrieve({
+      await testkit.retrieve({
         args: '--retrievetargetdir targetdir --metadata DOES_NOT_EXIST',
         exitCode: 1,
-      })) as JsonMap;
-      testkit.expect.errorToHaveName(retrieve, 'SfError');
+      });
     });
   });
 });


### PR DESCRIPTION
### What does this PR do?
test failures on https://github.com/forcedotcom/source-deploy-retrieve/pull/1374 
are because the nut specifies the error name, which SDR is changing.

### What issues does this PR fix or reference?
https://github.com/forcedotcom/source-deploy-retrieve/actions/runs/10081843723/job/27874888122?pr=1374
[@W-16324102@](https://gus.lightning.force.com/a07EE00001xOHgbYAG)